### PR TITLE
feat: sync remote auth with local MySQL

### DIFF
--- a/login.html
+++ b/login.html
@@ -27,7 +27,21 @@
       if (res.ok) {
         const data = await res.json();
         localStorage.setItem('access_token', data.access_token);
-        localStorage.setItem('username', username);
+        const meRes = await fetch('https://api.gluone.ru/auth/me', {
+          headers: { 'Authorization': 'Bearer ' + data.access_token }
+        });
+        if (meRes.ok) {
+          const me = await meRes.json();
+          localStorage.setItem('username', me.username);
+          localStorage.setItem('email', me.email);
+          localStorage.setItem('is_premium', me.is_premium);
+          localStorage.setItem('premium_expires_at', me.premium_expires_at || '');
+          await fetch('/users', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(me)
+          });
+        }
         alert('Успешный вход');
         location.href = 'profile.html';
       } else {

--- a/profile.html
+++ b/profile.html
@@ -24,12 +24,17 @@
       const token = localStorage.getItem('access_token');
       if (!token) return;
       const res = await fetch('https://api.gluone.ru/auth/me', {
-        headers: { 'Authorization': 'Bearer ' + token },
-        credentials: 'include'
+        headers: { 'Authorization': 'Bearer ' + token }
       });
       if (res.ok) {
         const data = await res.json();
+        localStorage.setItem('user_data', JSON.stringify(data));
         document.getElementById('info').textContent = JSON.stringify(data);
+        await fetch('/users', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data)
+        });
       } else {
         document.getElementById('info').textContent = 'Не удалось получить данные';
       }
@@ -44,6 +49,7 @@
       if (res.ok) {
         const data = await res.json();
         localStorage.setItem('access_token', data.access_token);
+        await loadMe();
         alert('Токен обновлен');
       } else {
         alert('Ошибка обновления');
@@ -56,6 +62,7 @@
         credentials: 'include'
       });
       localStorage.removeItem('access_token');
+      localStorage.removeItem('user_data');
       alert('Вы вышли');
       location.href = 'index.html';
     });
@@ -71,6 +78,11 @@
         body: JSON.stringify({ username, password })
       });
       if (res.ok) {
+        await fetch('/users', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username })
+        });
         localStorage.clear();
         alert('Аккаунт удален');
         location.href = 'index.html';

--- a/register.html
+++ b/register.html
@@ -29,7 +29,21 @@
       if (res.ok) {
         const data = await res.json();
         localStorage.setItem('access_token', data.access_token);
-        localStorage.setItem('username', username);
+        const meRes = await fetch('https://api.gluone.ru/auth/me', {
+          headers: { 'Authorization': 'Bearer ' + data.access_token }
+        });
+        if (meRes.ok) {
+          const me = await meRes.json();
+          localStorage.setItem('username', me.username);
+          localStorage.setItem('email', me.email);
+          localStorage.setItem('is_premium', me.is_premium);
+          localStorage.setItem('premium_expires_at', me.premium_expires_at || '');
+          await fetch('/users', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(me)
+          });
+        }
         alert('Успешная регистрация');
         location.href = 'profile.html';
       } else {

--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const axios = require('axios');
 const mysql = require('mysql2/promise');
 
 const app = express();
@@ -26,113 +25,35 @@ const pool = mysql.createPool({
   conn.release();
 })().catch(err => console.error(err));
 
-const api = axios.create({
-  baseURL: 'https://api.gluone.ru'
-});
-
-function forwardCookies(apiRes, res) {
-  const cookies = apiRes.headers['set-cookie'];
-  if (cookies) {
-    res.set('set-cookie', cookies);
-  }
-}
-
-app.post('/auth/register', async (req, res) => {
+// Upsert user info in local DB
+app.post('/users', async (req, res) => {
   try {
-    const { username, email, password } = req.body;
-    const apiRes = await api.post('/auth/web/register', { username, email, password }, {
-      headers: { cookie: req.headers.cookie || '' }
-    });
-    forwardCookies(apiRes, res);
-    const { is_premium, premium_expires_at } = apiRes.data;
+    const { username, email, is_premium, premium_expires_at } = req.body;
     await pool.execute(
       `INSERT INTO users (username, email, is_premium, premium_expires_at)
        VALUES (?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE email=VALUES(email), is_premium=VALUES(is_premium), premium_expires_at=VALUES(premium_expires_at)`,
-      [username, email, is_premium, premium_expires_at ? new Date(premium_expires_at) : null]
+      [
+        username,
+        email,
+        is_premium,
+        premium_expires_at ? new Date(premium_expires_at) : null
+      ]
     );
-    res.json(apiRes.data);
-  } catch (e) {
-    res.status(e.response?.status || 500).send(e.response?.data || { error: e.message });
-  }
-});
-
-app.post('/auth/login', async (req, res) => {
-  try {
-    const { username, password } = req.body;
-    const apiRes = await api.post('/auth/web/login', { username, password }, {
-      headers: { cookie: req.headers.cookie || '' }
-    });
-    forwardCookies(apiRes, res);
-    const { is_premium, premium_expires_at } = apiRes.data;
-    await pool.execute(
-      `UPDATE users SET is_premium=?, premium_expires_at=? WHERE username=?`,
-      [is_premium, premium_expires_at ? new Date(premium_expires_at) : null, username]
-    );
-    res.json(apiRes.data);
-  } catch (e) {
-    res.status(e.response?.status || 500).send(e.response?.data || { error: e.message });
-  }
-});
-
-app.post('/auth/refresh', async (req, res) => {
-  try {
-    const apiRes = await api.post('/auth/web/refresh', {}, {
-      headers: { cookie: req.headers.cookie || '' }
-    });
-    forwardCookies(apiRes, res);
-    res.json(apiRes.data);
-  } catch (e) {
-    res.status(e.response?.status || 500).send(e.response?.data || { error: e.message });
-  }
-});
-
-app.post('/auth/logout', async (req, res) => {
-  try {
-    const apiRes = await api.post('/auth/web/logout', {}, {
-      headers: { cookie: req.headers.cookie || '' }
-    });
-    forwardCookies(apiRes, res);
     res.status(204).send();
   } catch (e) {
-    res.status(e.response?.status || 500).send(e.response?.data || { error: e.message });
+    res.status(500).json({ error: e.message });
   }
 });
 
-app.post('/auth/change-password', async (req, res) => {
-  try {
-    const apiRes = await api.post('/auth/web/change-password', req.body, {
-      headers: { cookie: req.headers.cookie || '' }
-    });
-    forwardCookies(apiRes, res);
-    res.status(apiRes.status).send(apiRes.data);
-  } catch (e) {
-    res.status(e.response?.status || 500).send(e.response?.data || { error: e.message });
-  }
-});
-
-app.post('/auth/delete', async (req, res) => {
+// Remove user from local DB
+app.delete('/users', async (req, res) => {
   try {
     const { username } = req.body;
-    const apiRes = await api.post('/auth/web/delete', req.body, {
-      headers: { cookie: req.headers.cookie || '' }
-    });
-    forwardCookies(apiRes, res);
     await pool.execute(`DELETE FROM users WHERE username=?`, [username]);
-    res.status(apiRes.status).send(apiRes.data);
+    res.status(204).send();
   } catch (e) {
-    res.status(e.response?.status || 500).send(e.response?.data || { error: e.message });
-  }
-});
-
-app.get('/auth/me', async (req, res) => {
-  try {
-    const apiRes = await api.get('/auth/me', {
-      headers: { authorization: req.headers.authorization }
-    });
-    res.json(apiRes.data);
-  } catch (e) {
-    res.status(e.response?.status || 500).send(e.response?.data || { error: e.message });
+    res.status(500).json({ error: e.message });
   }
 });
 


### PR DESCRIPTION
## Summary
- Expose `/users` service that writes user records to the local MySQL database
- Call remote `api.gluone.ru` auth endpoints and sync profile info to the local database

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b0103447488327a323fc5b9eda5b42