### PR TITLE
feat: add env-based db config

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,11 +6,15 @@ app.use(express.json());
 app.use(express.static(__dirname));
 
 app.get('/check-db', async (req, res) => {
+  // Allow overriding connection settings via environment variables so the
+  // application can connect to the local database by default but still be
+  // configurable in different environments.
   const connectionConfig = {
-    host: 'localhost',
-    user: 'u3239193_default',
-    password: 'LX59kglhVRs17i7R',
-    database: 'u3239193_default'
+    host: process.env.DB_HOST || '127.0.0.1',
+    user: process.env.DB_USER || 'u3239193_default',
+    password: process.env.DB_PASSWORD || 'LX59kglhVRs17i7R',
+    database: process.env.DB_NAME || 'u3239193_default',
+    port: process.env.DB_PORT ? Number(process.env.DB_PORT) : 3306
   };
 
   try {


### PR DESCRIPTION
## Summary
- allow configuration of database connection via env vars with local defaults

## Testing
- `npm test` (fails: Error: no test specified)
- `curl http://localhost:8080/check-db` (fails: connect ECONNREFUSED 127.0.0.1:3306)


------
https://chatgpt.com/codex/tasks/task_e_68b01eba0e248327966156390dc27651