### PR TITLE
feat: insert db record on root request

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,11 +154,11 @@
     checkBtn.addEventListener('click', async () => {
       dbResult.textContent = 'Проверка...';
       try {
-        const baseUrl =
-          window.location.origin && window.location.origin !== 'null'
-            ? window.location.origin
-            : 'http://localhost:8080';
-        const response = await fetch(`${baseUrl}/check-db`);
+        // Запрашиваем тот же хост, с которого загружена страница.
+        // Это избегает ошибок типа "The string did not match the expected pattern"
+        // когда `window.location.origin` недоступен или содержит невалидное значение
+        // (например, при открытии файла напрямую из файловой системы).
+        const response = await fetch('/check-db');
         const data = await response.json();
         if (data.success) {
           dbResult.textContent = data.tables.join(', ');

--- a/server.js
+++ b/server.js
@@ -3,20 +3,34 @@ const mysql = require('mysql2/promise');
 
 const app = express();
 app.use(express.json());
+
+// Shared connection configuration to allow environment overrides while
+// providing sensible defaults for the current hosting setup.
+const connectionConfig = {
+  host: process.env.DB_HOST || '127.0.0.1',
+  user: process.env.DB_USER || 'u3239193_default',
+  password: process.env.DB_PASSWORD || 'LX59kglhVRs17i7R',
+  database: process.env.DB_NAME || 'u3239193_default',
+  port: process.env.DB_PORT ? Number(process.env.DB_PORT) : 3306
+};
+
+// Hitting the site root will insert a new row into the `users_rf` table to
+// verify that the database connection works and data is persisted.
+app.get('/', async (req, res) => {
+  try {
+    const connection = await mysql.createConnection(connectionConfig);
+    const [result] = await connection.query('INSERT INTO users_rf () VALUES ()');
+    await connection.end();
+    res.json({ success: true, insertedId: result.insertId });
+  } catch (err) {
+    res.status(500).json({ success: false, message: err.message || err.code });
+  }
+});
+
+// Serve static assets for any other routes.
 app.use(express.static(__dirname));
 
 app.get('/check-db', async (req, res) => {
-  // Allow overriding connection settings via environment variables so the
-  // application can connect to the local database by default but still be
-  // configurable in different environments.
-  const connectionConfig = {
-    host: process.env.DB_HOST || '127.0.0.1',
-    user: process.env.DB_USER || 'u3239193_default',
-    password: process.env.DB_PASSWORD || 'LX59kglhVRs17i7R',
-    database: process.env.DB_NAME || 'u3239193_default',
-    port: process.env.DB_PORT ? Number(process.env.DB_PORT) : 3306
-  };
-
   try {
     const connection = await mysql.createConnection(connectionConfig);
     const [rows] = await connection.query('SHOW TABLES');


### PR DESCRIPTION
## Summary
- add shared DB config
- insert a new row into `users_rf` when `/` is requested to verify connection

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b025cd17b08327944bcc0c2c2dc855