### PR TITLE
Add Tinkoff subscription payment flow

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -8,6 +8,14 @@
   <h1>Личный кабинет</h1>
   <div id="info"></div>
 
+  <h2>Подписка</h2>
+  <div id="plans">
+    <button data-plan="month">1 месяц – 99 ₽</button>
+    <button data-plan="quarter">3 месяца – 279 ₽</button>
+    <button data-plan="half">6 месяцев – 499 ₽</button>
+    <button data-plan="year">12 месяцев – 899 ₽</button>
+  </div>
+
   <h2>Смена пароля</h2>
   <form id="change-password">
     <input type="password" name="old_password" placeholder="Старый пароль" required>
@@ -100,6 +108,29 @@
       } else {
         alert('Ошибка смены пароля');
       }
+    });
+
+    // ---- Subscription payment ----
+    document.querySelectorAll('#plans button').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const plan = btn.dataset.plan;
+        try {
+          const res = await fetch('/api/create-payment', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ plan })
+          });
+          const data = await res.json();
+          if (data && data.PaymentURL) {
+            window.location.href = data.PaymentURL;
+          } else {
+            alert('Ошибка оплаты');
+          }
+        } catch (err) {
+          console.error(err);
+          alert('Ошибка связи с сервером');
+        }
+      });
     });
   </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -1,8 +1,70 @@
+// Simple express server that serves static files and exposes
+// a small API for creating Tinkoff payment sessions.
 const express = require('express');
+const axios = require('axios');
+const crypto = require('crypto');
+
 const app = express();
 app.use(express.json());
+
 // Serve static assets for any other routes.
 app.use(express.static(__dirname));
+
+// --- Payment API ---------------------------------------------------------
+// Mapping between plan identifiers and price in kopecks
+const PLAN_PRICES = {
+  month: 9900, // 99.00 RUB
+  quarter: 27900, // 279.00 RUB
+  half: 49900, // 499.00 RUB
+  year: 89900 // 899.00 RUB
+};
+
+// Helper for building the token according to Tinkoff documentation
+function generateToken(params, password) {
+  const ordered = Object.keys(params)
+    .sort()
+    .map((k) => params[k])
+    .join('');
+  return crypto
+    .createHash('sha256')
+    .update(ordered + password)
+    .digest('hex');
+}
+
+// Endpoint to initialise payment
+app.post('/api/create-payment', async (req, res) => {
+  const { plan } = req.body;
+  const amount = PLAN_PRICES[plan];
+  if (!amount) {
+    return res.status(400).json({ error: 'Unknown plan' });
+  }
+
+  const payload = {
+    TerminalKey: process.env.TINKOFF_TERMINAL_KEY || 'TinkoffBankTest',
+    Amount: amount,
+    OrderId: Date.now().toString(),
+    Description: `GluOne subscription: ${plan}`,
+    SuccessURL: 'https://gluone.ru/profile.html',
+    FailURL: 'https://gluone.ru/profile.html'
+  };
+
+  // Use the password from env or test password
+  const password = process.env.TINKOFF_PASSWORD || 'TinkoffBankTest';
+  payload.Token = generateToken(payload, password);
+
+  try {
+    const { data } = await axios.post(
+      'https://securepay.tinkoff.ru/v2/Init',
+      payload
+    );
+    res.json(data);
+  } catch (err) {
+    console.error('Payment init failed', err.message);
+    res.status(500).json({ error: 'Payment init failed' });
+  }
+});
+
+// -------------------------------------------------------------------------
 
 const port = process.env.PORT || 8080;
 app.listen(port, () => console.log(`Server running on port ${port}`));


### PR DESCRIPTION
## Summary
- add Express endpoint to initialise Tinkoff payments
- provide subscription plan selection on profile page

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b03e93fa048327b1f0b8ae1355757f