### PR TITLE
feat: add design tokens and theme support

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,54 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>GluOne – Your Diabetes Companion</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <style>
-    :root {
-      --primary-color: #3b82f6;
-      --secondary-color: #f97316;
-      --bg-color: #f9fafb;
-      --card-bg: #ffffff;
-      --text-color: #1f2937;
-      --muted-color: #6b7280;
-    }
-    * { box-sizing: border-box; margin: 0; padding: 0; font-family: 'Inter', sans-serif; }
-    body { background: var(--bg-color); color: var(--text-color); }
-    header {
-      background: var(--primary-color);
-      color: white;
-      padding: 2rem 1rem;
-      text-align: center;
-      position: relative;
-    }
-    header h1 { font-size: 2.5rem; margin-bottom: 0.5rem; }
-    header p { font-size: 1.25rem; }
-    .lang-switch {
-      position: absolute;
-      top: 1rem;
-      right: 1rem;
-    }
-    .lang-switch select {
-      padding: 0.25rem;
-      border-radius: 0.25rem;
-      border: none;
-      font-weight: 600;
-      cursor: pointer;
-    }
-    .container { max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
-    .features { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px,1fr)); gap: 1.5rem; margin-top: 2rem; }
-    .feature { background: var(--card-bg); border-radius: 0.75rem; padding: 1rem; box-shadow: 0 5px 10px rgba(0,0,0,0.05); }
-    .feature h3 { color: var(--secondary-color); margin-bottom: 0.5rem; font-size: 1.1rem; }
-    .feature p { font-size: 0.9rem; color: var(--muted-color); }
-    .cta { text-align: center; margin: 3rem 0; }
-    .cta a { display: inline-block; padding: 1rem 2rem; background: var(--secondary-color); color: white; text-decoration: none; font-weight: 600; border-radius: 0.5rem; transition: background 0.2s ease; }
-    .cta a:hover { background: #d65a0e; }
-    footer { text-align: center; padding: 2rem 1rem; font-size: 0.85rem; color: var(--muted-color); }
-    footer a { color: var(--primary-color); text-decoration: none; }
-    .lang { display: none; }
-    .lang.active { display: block; }
-  </style>
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <header>
+    <div class="theme-switch">
+      <select id="theme-select">
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+      </select>
+    </div>
     <div class="lang-switch">
       <select id="language-select">
         <option value="ru">RU</option>
@@ -69,7 +31,6 @@
   </nav>
 
   <section class="container">
-    <!-- Russian content -->
     <div data-lang="ru" class="lang active">
       <p>GluOne помогает вести цифровой дневник диабета. Отслеживайте уровень глюкозы, дозы инсулина, питание, давление, активность и приём медикаментов — всё локально и без регистрации.</p>
       <div class="features">
@@ -83,7 +44,6 @@
       <div class="cta"><a href="#">Скачать в App Store</a></div>
     </div>
 
-    <!-- English content -->
     <div data-lang="en" class="lang">
       <p>GluOne helps you keep a digital diabetes journal—all data stays on your device. Track glucose, insulin, meals, blood pressure, activity, and meds without any signup.</p>
       <div class="features">
@@ -101,11 +61,7 @@
   <footer>
     <p>ИП Киселев АБ ОГРНИП 324619600076322</p>
     <p>
-      <a
-        id="privacy-link"
-        href="https://gluone.ru/privacy.html"
-        target="_blank"
-      >
+      <a id="privacy-link" href="https://gluone.ru/privacy.html" target="_blank">
         Политика конфиденциальности
       </a>
     </p>
@@ -114,6 +70,7 @@
 
   <script>
     const select = document.getElementById('language-select');
+    const themeSelect = document.getElementById('theme-select');
     const sections = document.querySelectorAll('[data-lang]');
     const tagline = document.getElementById('tagline');
     const privacyLink = document.getElementById('privacy-link');
@@ -128,21 +85,29 @@
       en: 'Privacy Policy'
     };
 
+    function applyTheme(theme) {
+      if (theme === 'dark') {
+        document.body.classList.add('dark');
+      } else {
+        document.body.classList.remove('dark');
+      }
+      localStorage.setItem('theme', theme);
+    }
+
     select.addEventListener('change', () => {
       const lang = select.value;
-
-      // Переключаем видимость языковых секций
       sections.forEach(sec =>
         sec.classList.toggle('active', sec.getAttribute('data-lang') === lang)
       );
-
-      // Меняем текст слогана
       tagline.textContent = taglines[lang];
-
-      // Меняем текст ссылки на политику
       privacyLink.textContent = privacyTexts[lang];
     });
 
-</script>
+    themeSelect.addEventListener('change', () => applyTheme(themeSelect.value));
+
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    themeSelect.value = savedTheme;
+    applyTheme(savedTheme);
+  </script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -3,8 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>Вход</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+  <script>if(localStorage.getItem('theme')==='dark'){document.body.classList.add('dark');}</script>
   <h1>Вход</h1>
   <form id="login-form">
     <input name="username" placeholder="Имя пользователя" required>
@@ -29,7 +32,6 @@
         localStorage.setItem('access_token', data.access_token);
 
         const meRes = await fetch('https://api.gluone.ru/auth/web/me', {
-
           headers: { 'Authorization': 'Bearer ' + data.access_token }
         });
         if (meRes.ok) {

--- a/privacy.html
+++ b/privacy.html
@@ -4,29 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Политика конфиденциальности GluOne</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-  <style>
-    :root {
-      --primary-color: #3b82f6;
-      --bg-color: #f9fafb;
-      --text-color: #1f2937;
-      --muted-color: #4b5563;
-    }
-    body { margin:0; padding:0; font-family:'Inter',sans-serif; background:var(--bg-color); color:var(--text-color); }
-    header { background:var(--primary-color); color:#fff; padding:1rem; text-align:center; position:relative; }
-    header h1 { margin:0; font-size:1.5rem; }
-    .lang-switch { position:absolute; top:1rem; right:1rem; }
-    .lang-switch select { padding:0.25rem; border:none; border-radius:0.25rem; font-weight:600; cursor:pointer; }
-    .content { max-width:800px; margin:2rem auto; padding:0 1rem; }
-    h2 { margin-top:1.5rem; color:var(--primary-color); }
-    p, li { line-height:1.6; }
-    ul { margin-left:1.2rem; }
-    footer { text-align:center; padding:1rem; font-size:0.85rem; color:var(--muted-color); }
-    .lang { display:none; }
-    .lang.active { display:block; }
-  </style>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+  <script>if(localStorage.getItem('theme')==='dark'){document.body.classList.add('dark');}</script>
   <header>
     <h1>Политика конфиденциальности</h1>
     <div class="lang-switch">

--- a/profile.html
+++ b/profile.html
@@ -3,8 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>Личный кабинет</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+  <script>if(localStorage.getItem('theme')==='dark'){document.body.classList.add('dark');}</script>
   <h1>Личный кабинет</h1>
   <div id="info"></div>
 
@@ -31,9 +34,8 @@
     async function loadMe() {
       const token = localStorage.getItem('access_token');
       if (!token) return;
-      
-      const res = await fetch('https://api.gluone.ru/auth/web/me', {
 
+      const res = await fetch('https://api.gluone.ru/auth/web/me', {
         headers: { 'Authorization': 'Bearer ' + token }
       });
       if (res.ok) {

--- a/register.html
+++ b/register.html
@@ -3,8 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>Регистрация</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+  <script>if(localStorage.getItem('theme')==='dark'){document.body.classList.add('dark');}</script>
   <h1>Регистрация</h1>
   <form id="register-form">
     <input name="username" placeholder="Имя пользователя" required>
@@ -31,7 +34,6 @@
         localStorage.setItem('access_token', data.access_token);
 
         const meRes = await fetch('https://api.gluone.ru/auth/web/me', {
-
           headers: { 'Authorization': 'Bearer ' + data.access_token }
         });
         if (meRes.ok) {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,76 @@
+:root {
+  --brand-600: #7C4DFF;
+  --brand-400: #9E7CFF;
+  --brand-200: #C9B9FF;
+  --accent-cyan: #21D4FD;
+
+  --bg: #ffffff;
+  --bg-elevated: #f9fafb;
+  --card: #ffffff;
+  --border: #e5e7eb;
+  --muted: #6b7280;
+  --text: #1f2937;
+  --text-muted: #6b7280;
+
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-2xl: 24px;
+}
+
+.dark {
+  --bg: #1f2937;
+  --bg-elevated: #374151;
+  --card: #1f2937;
+  --border: #4b5563;
+  --muted: #9ca3af;
+  --text: #f9fafb;
+  --text-muted: #9ca3af;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', sans-serif;
+}
+
+header {
+  background: var(--brand-600);
+  color: #fff;
+  padding: 2rem 1rem;
+  text-align: center;
+  position: relative;
+}
+header h1 { font-size: 2.5rem; margin-bottom: 0.5rem; }
+header p { font-size: 1.25rem; }
+
+.lang-switch { position: absolute; top: 1rem; right: 1rem; }
+.theme-switch { position: absolute; top: 1rem; left: 1rem; }
+.lang-switch select, .theme-switch select {
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.container { max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
+.features { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px,1fr)); gap: 1.5rem; margin-top: 2rem; }
+.feature { background: var(--card); border-radius: 0.75rem; padding: 1rem; box-shadow: 0 5px 10px rgba(0,0,0,0.05); }
+.feature h3 { color: var(--brand-600); margin-bottom: 0.5rem; font-size: 1.1rem; }
+.feature p { font-size: 0.9rem; color: var(--text-muted); }
+
+.cta { text-align: center; margin: 3rem 0; }
+.cta a { display: inline-block; padding: 1rem 2rem; background: var(--brand-600); color: #fff; text-decoration: none; font-weight: 600; border-radius: 0.5rem; transition: background 0.2s ease; }
+.cta a:hover { background: var(--brand-400); }
+
+footer { text-align: center; padding: 2rem 1rem; font-size: 0.85rem; color: var(--muted); }
+footer a { color: var(--brand-600); text-decoration: none; }
+
+.lang { display: none; }
+.lang.active { display: block; }
+
+.content { max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
+h2 { margin-top: 1.5rem; color: var(--brand-600); }
+p, li { line-height: 1.6; }
+ul { margin-left: 1.2rem; }


### PR DESCRIPTION
## Summary
- centralise visual tokens in shared stylesheet with light and dark variables
- enable theme switching and token-based styles on landing page
- apply shared styles across auth, profile, and policy pages

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b0494c0f04832789aae714abf947c9