### PR TITLE
Fix vertical alignment of password toggle buttons

### DIFF
--- a/assets/css/cabinet.css
+++ b/assets/css/cabinet.css
@@ -178,8 +178,8 @@
 }
 
 /* ==== Показ/скрытие пароля (иконка как в логине) ==== */
-.form-field.has-toggle { position: relative; }
-.form-field.has-toggle input { padding-right: 44px; }
+.form-field .field-wrap{ position:relative; }
+.form-field .field-wrap input{ padding-right:44px; }
 
 .toggle-pass{
   position:absolute;

--- a/assets/js/cabinet.js
+++ b/assets/js/cabinet.js
@@ -289,10 +289,13 @@ import { KEYS, load, del } from './storage.js';
   // Кнопка-глаз для password-поля (как в авторизации)
   function installPasswordToggle(inputEl) {
     if (!inputEl) return;
-    const host = inputEl.closest('.form-field') || inputEl.parentElement;
-    if (!host || host.querySelector('.toggle-pass')) return;
+    const label = inputEl.closest('.form-field');
+    if (!label || label.querySelector('.toggle-pass')) return;
 
-    host.classList.add('has-toggle');
+    const wrap = document.createElement('div');
+    wrap.className = 'field-wrap';
+    label.replaceChild(wrap, inputEl);
+    wrap.appendChild(inputEl);
 
     const btn = document.createElement('button');
     btn.type = 'button';
@@ -323,7 +326,7 @@ import { KEYS, load, del } from './storage.js';
       const v = inputEl.value; inputEl.setSelectionRange(v.length, v.length);
     });
 
-    host.appendChild(btn);
+    wrap.appendChild(btn);
   }
 
   // ===== смена пароля


### PR DESCRIPTION
## Summary
- Wrap password fields with a relative container for better control
- Absolutely position show/hide button within the wrapper to center it vertically

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b97965242883278c1eea70f080c5b5