### PR TITLE
Remove client-side auth validators

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -10,8 +10,6 @@ import { KEYS, save } from './storage.js';
   const passI   = document.getElementById('password');
   const toggle  = document.getElementById('togglePass');
   const submit  = document.getElementById('submitBtn');
-  const loginE  = document.getElementById('loginError');
-  const passE   = document.getElementById('passwordError');
   const formMsg = document.getElementById('formMsg');
   const forgotLink = document.getElementById('forgotLink');
 
@@ -182,13 +180,7 @@ import { KEYS, save } from './storage.js';
     });
   }
 
-  const explainLogin = (el) => el.validity.valueMissing ? 'Введите логин.' : (!el.checkValidity() ? 'Некорректный логин.' : '');
-  const explainPass  = (el) => el.validity.valueMissing ? 'Введите пароль.' : (!el.checkValidity() ? 'Некорректный пароль.' : '');
-  const showError    = (el, errEl, text) => { errEl.textContent = text; errEl.hidden = !text; el.setAttribute('aria-invalid','true'); };
-  const clearError   = (el, errEl) => { errEl.textContent = ''; errEl.hidden = true; el.removeAttribute('aria-invalid'); };
-
-  loginI.addEventListener('input', () => clearError(loginI, loginE));
-  passI .addEventListener('input', () => clearError(passI, passE));
+  // валидация логина и пароля выполняется на сервере
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -196,11 +188,6 @@ import { KEYS, save } from './storage.js';
     formMsg.textContent = '';
     formMsg.className   = 'form-hint';
     formMsg.style.color = '';
-
-    let invalid = false;
-    if (!loginI.checkValidity()) { showError(loginI, loginE, explainLogin(loginI)); invalid = true; }
-    if (!passI.checkValidity())  { showError(passI,  passE,  explainPass(passI));   invalid = true; }
-    if (invalid) return;
 
     submit.disabled = true; submit.style.opacity = .7;
     const { ok, status, data } = await authLogin(loginI.value.trim(), passI.value);

--- a/auth.html
+++ b/auth.html
@@ -41,11 +41,8 @@
             <input id="login" name="login" type="text"
                    autocomplete="username" autocapitalize="none" autocorrect="off" spellcheck="false"
                    placeholder="Введите логин"
-                   class="field"
-                   required minlength="3" maxlength="30"
-                   pattern="^[A-Za-z0-9._-]{3,30}$" />
+                   class="field" />
           </div>
-          <p id="loginError" class="form-error" hidden style="margin-top:6px;"></p>
 
           <!-- ПАРОЛЬ -->
           <label for="password" style="display:block; font-weight:600; color:var(--ink-2); font-size:14px; margin-top:16px;">Пароль</label>
@@ -53,9 +50,7 @@
             <input id="password" name="password" type="password"
                    autocomplete="current-password"
                    placeholder="Введите пароль"
-                   class="field field--with-icon"
-                   required minlength="12" maxlength="72"
-                   pattern="^(?=.{12,72}$)(?!.*\s)(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^\\w\\s])[\\x21-\\x7E]+$" />
+                   class="field field--with-icon" />
             <button type="button" id="togglePass" class="icon-btn" aria-label="Показать пароль" title="Показать пароль" data-state="hidden">
               <!-- глаз -->
               <svg class="i i-eye" width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -70,7 +65,6 @@
               </svg>
             </button>
           </div>
-          <p id="passwordError" class="form-error" hidden style="margin-top:6px;"></p>
 
           <!-- Ссылка на восстановление (модалка создаётся динамически в auth.js) -->
           <div style="display:flex; justify-content:flex-end; margin-top:8px;">


### PR DESCRIPTION
## Summary
- drop HTML validation attributes from login and password fields
- rely on server-side login/password checks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9930e12e88327a3babd81f76bf5d3