### PR TITLE
Fix dark mode home button contrast on cabinet page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -134,6 +134,12 @@ button, .btn-hero, .btn-outline {
 .btn-hero:hover{ transform:translateY(-1px); box-shadow:0 6px 16px rgba(2,6,23,.12); filter: saturate(110%); }
 .btn-hero:active{ transform:translateY(0); }
 .btn-hero:focus-visible{ outline:none; box-shadow:0 0 0 3px color-mix(in oklab, var(--ring) 65%, transparent); }
+@media (prefers-color-scheme: dark){
+  .btn-hero{
+    background:#fff;
+    color:var(--bg);
+  }
+}
 
 /* Кнопка-обводка */
 .btn-outline{


### PR DESCRIPTION
## Summary
- make hero buttons use light background and dark text in dark mode for better readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99452a844832788fd05f01eb0f2f6