### PR TITLE
Fix OTP input focus forwarding

### DIFF
--- a/assets/js/confirm.js
+++ b/assets/js/confirm.js
@@ -145,9 +145,10 @@ import { KEYS, load, save, del } from './storage.js';
           idx++;
         }
 
-        if (el.value && idx < inputs.length) {
-          // Перенос фокуса после завершения текущего события ввода
-          setTimeout(() => inputs[idx].focus(), 0);
+        if (el.value) {
+          // Переносим фокус на первое свободное поле
+          const empty = inputs.find(inp => !inp.value);
+          if (empty) empty.focus();
         }
 
         maybeVerify();

--- a/confirm.html
+++ b/confirm.html
@@ -45,7 +45,7 @@
                    inputmode="numeric" pattern="\d*" maxlength="1"
                    autocomplete="one-time-code"
                    aria-label="Первая цифра" aria-describedby="codeError confirmMsg"
-                   enterkeyhint="next" autofocus />
+                   enterkeyhint="next" />
             <input class="otp-input"
                    inputmode="numeric" pattern="\d*" maxlength="1"
                    aria-label="Вторая цифра" aria-describedby="codeError confirmMsg"


### PR DESCRIPTION
## Summary
- ensure OTP inputs advance focus to the next empty field
- remove HTML autofocus from first OTP cell to prevent refocusing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba908268a0832784c229682155bb90