### PR TITLE
fix: redirect unauthorized to auth

### DIFF
--- a/cabinet.html
+++ b/cabinet.html
@@ -25,6 +25,15 @@
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="bg-slate-50">
+  <script>
+    try {
+      if (!sessionStorage.getItem('gluone:auth_token')) {
+        window.location.href = '/auth.html?next=%2Fcabinet.html';
+      }
+    } catch (e) {
+      window.location.href = '/auth.html?next=%2Fcabinet.html';
+    }
+  </script>
   <div id="root"></div>
   <script type="text/babel" data-type="module" data-presets="env,react" src="assets/js/cabinet.jsx"></script>
 


### PR DESCRIPTION
## Summary
- add sessionStorage check in cabinet page to redirect unauthorized users to auth page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baab37dab08327886f5d2d52a8b6b8