### PR TITLE
Configure payment widget to send SKU and device data

### DIFF
--- a/assets/js/cabinet.js
+++ b/assets/js/cabinet.js
@@ -401,9 +401,10 @@ function AccountApp() {
         language: "ru",
         amount: gatewayAmountString(amountRub),
         order: orderId,
-        description: `GluOne Premium \u2014 \u043F\u0440\u043E\u0434\u043B\u0435\u043D\u0438\u0435 (${selectedPlan.name || selectedPlan.duration_months + " \u043C\u0435\u0441."})`,
+        description: selectedPlan.sku,
         email: accountEmail,
-        customerkey: profile?.id || profile?.username || profile?.email
+        customerkey: profile?.id,
+        DATA: currentPremiumDeviceId ? `device_id=${currentPremiumDeviceId}` : ''
       });
     } catch (e) {
       console.error(e);

--- a/assets/js/cabinet.jsx
+++ b/assets/js/cabinet.jsx
@@ -625,9 +625,10 @@ function AccountApp() {
         language: "ru",
         amount: gatewayAmountString(amountRub),
         order: orderId,
-        description: `GluOne Premium — продление (${selectedPlan.name || selectedPlan.duration_months + ' мес.'})`,
+        description: selectedPlan.sku,
         email: accountEmail,
-        customerkey: profile?.id || profile?.username || profile?.email,
+        customerkey: profile?.id,
+        DATA: currentPremiumDeviceId ? `device_id=${currentPremiumDeviceId}` : '',
       });
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
## Summary
- send selected plan SKU in widget description
- include user and device identifiers as hidden fields

## Testing
- `node --check assets/js/cabinet.js`


------
https://chatgpt.com/codex/tasks/task_e_68bab9ad514883278fe620c04770526a