### PR TITLE
feat: integrate subscription payment order

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -277,3 +277,26 @@ export function authSubscriptions(accessToken) {
     }
   });
 }
+
+/**
+ * Создать заказ на оплату подписки.
+ * POST /auth/web/payments/order
+ * @param {string} accessToken
+ * @param {string} userId
+ * @param {string} [deviceId]
+ * @param {string} subscriptionPlanId
+ * @returns {Promise<{ok: boolean, status: number, data: {order_id: string} | null}>}
+ */
+export function authCreateSubscriptionOrder(accessToken, userId, deviceId, subscriptionPlanId) {
+  const payload = { user_id: userId, subscription_plan_id: subscriptionPlanId };
+  if (deviceId) payload.device_id = deviceId;
+  return request('/auth/web/payments/order', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+      'Authorization': `Bearer ${accessToken}`
+    },
+    body: JSON.stringify(payload)
+  });
+}

--- a/assets/js/cabinet.jsx
+++ b/assets/js/cabinet.jsx
@@ -1,4 +1,4 @@
-import { authMe, authLogout, authDevices, authRevokeDevice, authDeleteDevice, authChangePassword, authDeleteAccount, authSubscriptions } from './api.js';
+import { authMe, authLogout, authDevices, authRevokeDevice, authDeleteDevice, authChangePassword, authDeleteAccount, authSubscriptions, authCreateSubscriptionOrder } from './api.js';
 import { KEYS, load, del } from './storage.js';
 
 const { useState, useEffect } = React;
@@ -615,10 +615,15 @@ function AccountApp() {
 
   const { ready: payReady, error: payError, openPayForm } = useTinkoffScript();
 
-  const handlePay = () => {
+  const handlePay = async () => {
     if (!selectedPlan || !payReady) return;
-    const orderId = `sub_${selectedPlan.id}_${Date.now()}`;
     try {
+      const order = await authCreateSubscriptionOrder(accessToken, profile?.id, currentPremiumDeviceId, selectedPlan.id);
+      const orderId = order?.data?.order_id;
+      if (!order.ok || !orderId) {
+        alert('Не удалось создать заказ. Попробуйте ещё раз.');
+        return;
+      }
       openPayForm({
         terminalkey: TINKOFF_TERMINAL_KEY,
         frame: "true",
@@ -632,7 +637,7 @@ function AccountApp() {
       });
     } catch (e) {
       console.error(e);
-      alert("Не удалось открыть оплату. Попробуйте ещё раз.");
+      alert('Не удалось открыть оплату. Попробуйте ещё раз.');
     }
   };
 


### PR DESCRIPTION
## Summary
- add API helper to create subscription payment orders
- fetch server order_id for Tinkoff form in cabinet

## Testing
- `npm test` *(fails: missing package.json)*
- `node --check --experimental-default-type=module assets/js/api.js`
- `node --check --experimental-default-type=module assets/js/cabinet.js`


------
https://chatgpt.com/codex/tasks/task_e_68bac7bab37c83279ede91116d6fcf93