### PR TITLE
Enforce device ID for subscription orders

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -288,8 +288,10 @@ export function authSubscriptions(accessToken) {
  * @returns {Promise<{ok: boolean, status: number, data: {order_id: string} | null}>}
  */
 export function authCreateSubscriptionOrder(accessToken, userId, deviceId, subscriptionPlanId) {
-  const payload = { user_id: userId, subscription_plan_id: subscriptionPlanId };
-  if (deviceId) payload.device_id = deviceId;
+  if (!deviceId) {
+    throw new Error('deviceId is required to create subscription order');
+  }
+  const payload = { user_id: userId, device_id: deviceId, subscription_plan_id: subscriptionPlanId };
   return request('/auth/web/payments/order', {
     method: 'POST',
     headers: {

--- a/assets/js/cabinet.js
+++ b/assets/js/cabinet.js
@@ -414,9 +414,7 @@ function AccountApp() {
         amount: gatewayAmountString(amountRub),
         order: orderId,
         description: selectedPlan.sku,
-        email: accountEmail,
-        customerkey: profile?.id,
-        DATA: currentPremiumDeviceId ? `device_id=${currentPremiumDeviceId}` : ''
+        email: accountEmail
       });
     } catch (e) {
       console.error(e);

--- a/assets/js/cabinet.jsx
+++ b/assets/js/cabinet.jsx
@@ -640,8 +640,6 @@ function AccountApp() {
         order: orderId,
         description: selectedPlan.sku,
         email: accountEmail,
-        customerkey: profile?.id,
-        DATA: currentPremiumDeviceId ? `device_id=${currentPremiumDeviceId}` : '',
       });
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
## Summary
- Require device ID when creating subscription orders
- Pass only order ID to payment widget, removing customer and device data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bad9259a9483278069b28c7b469b7f