### PR TITLE
Use popup view for Tinkoff widget

### DIFF
--- a/assets/css/cabinet.css
+++ b/assets/css/cabinet.css
@@ -428,3 +428,19 @@
 }
 .transfer-item-title{ font-weight:700; color:var(--ink); }
 .transfer-item-sub{ font-size:12px; color:#64748b; }
+
+/* ===== Tinkoff Pay widget tweaks ===== */
+.t-wrapper{
+  display:flex !important;
+  align-items:center;
+  justify-content:center;
+}
+.t-frame-wrapper{
+  width:auto !important;
+  height:auto !important;
+  max-width:440px;
+}
+.t-frame{
+  width:100% !important;
+  height:auto !important;
+}

--- a/assets/js/cabinet.jsx
+++ b/assets/js/cabinet.jsx
@@ -64,12 +64,12 @@ function useTinkoffScript() {
 
   const openPayForm = (params) => {
     if (window.Tinkoff?.createPayment) {
-      // Современный способ: напрямую вызываем createPayment без скрытой формы
-      window.Tinkoff.createPayment(params);
+      // Современный способ: открываем виджет в компактном попапе
+      window.Tinkoff.createPayment({ ...params, view: "popup" });
       return;
     }
     if (!window.pay) throw new Error("Виджет оплаты ещё не готов");
-    const form = buildTinkoffForm(params);
+    const form = buildTinkoffForm({ ...params, frame: "popup" });
     document.body.appendChild(form);
     try {
       window.pay(form);
@@ -654,7 +654,6 @@ function AccountApp() {
       }
       openPayForm({
         terminalkey: TINKOFF_TERMINAL_KEY,
-        frame: "true",
         language: "ru",
         amount: gatewayAmountString(amountRub),
         order: orderId,


### PR DESCRIPTION
## Summary
- Open Tinkoff payment widget in popup mode to avoid oversized window
- Tweak CSS for Tinkoff Pay wrapper and frame to fit content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baeb790ce8832799fbb717c56e3ac1