### PR TITLE
feat: show premium status in device and subscription cards

### DIFF
--- a/assets/js/cabinet/devices.js
+++ b/assets/js/cabinet/devices.js
@@ -9,6 +9,8 @@ export function DeviceItem({ device, onRevoke, onDelete }) {
   const ip = device?.last_ip || "—";
   const created = device?.created_at ? fmtDate(device.created_at) : "—";
   const active = device?.last_seen_at ? fmtDateTime(device.last_seen_at) : "—";
+  const isPremium = !!device?.is_premium;
+  const premiumUntil = device?.premium_expires_at ? fmtDate(device.premium_expires_at) : "—";
   const revoked = !!device?.revoked;
   const deviceId = device?.device_id;
 
@@ -23,6 +25,8 @@ export function DeviceItem({ device, onRevoke, onDelete }) {
       React.createElement("div", { className: "text-slate-500" }, "Активность"), React.createElement("div", { className: "text-slate-800" }, active),
       React.createElement("div", { className: "text-slate-500" }, "Создано"), React.createElement("div", { className: "text-slate-800" }, created),
       React.createElement("div", { className: "text-slate-500" }, "IP"), React.createElement("div", { className: "text-slate-800" }, ip),
+      React.createElement("div", { className: "text-slate-500" }, "Премиум"), React.createElement("div", { className: "text-slate-800" }, isPremium ? "Активен" : "Нет"),
+      React.createElement("div", { className: "text-slate-500" }, "Действует до"), React.createElement("div", { className: "text-slate-800" }, isPremium ? premiumUntil : "—"),
       React.createElement("div", { className: "text-slate-500" }, "ID устройства"), React.createElement("div", { className: "text-slate-800 break-all" }, deviceId)
     ),
     React.createElement("div", { className: "mt-3 flex justify-end gap-2" },

--- a/assets/js/cabinet/panels.js
+++ b/assets/js/cabinet/panels.js
@@ -38,13 +38,17 @@ export function ProfilePanel({ profile }) {
   );
 }
 
-export function SubscriptionPanel({ onOpenTransfer, currentDeviceName, onPay, payReady, plans, selectedPlanId, setSelectedPlanId, amountRub, monthPrice, email, currentDeviceId }) {
+export function SubscriptionPanel({ onOpenTransfer, currentDeviceName, onPay, payReady, plans, selectedPlanId, setSelectedPlanId, amountRub, monthPrice, email, currentDeviceId, isPremium, premiumExpiresAt }) {
   return React.createElement("div", { className: "max-w-6xl" },
     React.createElement(SectionCard, { title: "Подписка Premium" },
       React.createElement("div", { className: "space-y-2 text-sm" },
         React.createElement("div", { className: "flex items-center justify-between" },
           React.createElement("span", { className: "text-slate-500" }, "Статус"),
-          React.createElement("span", { className: "font-medium text-emerald-700" }, "Активна")
+          React.createElement("span", { className: `font-medium ${isPremium ? "text-emerald-700" : "text-rose-600"}` }, isPremium ? "Активна" : "Неактивна")
+        ),
+        isPremium && React.createElement("div", { className: "flex items-center justify-between" },
+          React.createElement("span", { className: "text-slate-500" }, "Действует до"),
+          React.createElement("span", { className: "font-medium" }, fmtDate(premiumExpiresAt))
         ),
         React.createElement("div", { className: "flex items-center justify-between" },
           React.createElement("span", { className: "text-slate-500" }, "Устройство"),
@@ -71,7 +75,7 @@ export function SubscriptionPanel({ onOpenTransfer, currentDeviceName, onPay, pa
         React.createElement("input", { value: email, readOnly: true, className: "rounded-lg border border-slate-200 px-3 py-2 text-sm bg-slate-50 text-slate-700" })
       ),
       React.createElement("div", { className: "mt-4 flex gap-3" },
-        React.createElement("button", { disabled: !payReady || !selectedPlanId || !currentDeviceId, onClick: onPay, className: `rounded-xl px-4 py-2 font-medium text-white ${payReady ? "bg-indigo-600 hover:bg-indigo-700" : "bg-slate-400 cursor-not-allowed"}` }, "Продлить"),
+        React.createElement("button", { disabled: !payReady || !selectedPlanId || !currentDeviceId, onClick: onPay, className: `rounded-xl px-4 py-2 font-medium text-white ${payReady ? "bg-indigo-600 hover:bg-indigo-700" : "bg-slate-400 cursor-not-allowed"}` }, isPremium ? "Продлить" : "Купить"),
         React.createElement("button", { onClick: onOpenTransfer, className: "rounded-xl border border-slate-200 px-4 py-2 font-medium" }, "Сменить устройство")
       ),
       !payReady && React.createElement("div", { className: "mt-2 text-xs text-slate-500" }, "Загружаем виджет оплаты…")


### PR DESCRIPTION
## Summary
- Display premium status and expiry for each device
- Track premium info for current device and expose it to subscription panel
- Show premium expiration and dynamic purchase/renew text in subscription card

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check assets/js/cabinet/app.js`
- `node --check assets/js/cabinet/panels.js`
- `node --check assets/js/cabinet/devices.js`


------
https://chatgpt.com/codex/tasks/task_e_68be937b953883278888e490ced3fece