### PR TITLE
Remove debug assertions from Tinkoff widget

### DIFF
--- a/assets/js/cabinet/tinkoff.js
+++ b/assets/js/cabinet/tinkoff.js
@@ -64,12 +64,5 @@ export function useTinkoffScript() {
     finally { document.body.removeChild(form); }
   };
 
-  useEffect(() => {
-    const f = buildTinkoffForm({ terminalkey: "K", amount: "100", order: "o1" });
-    console.assert(f.elements.namedItem("terminalkey").value === "K", "[TEST] terminalkey mismatch");
-    console.assert(f.elements.namedItem("amount").value === "100", "[TEST] amount mismatch");
-    console.assert(f.elements.namedItem("order").value === "o1", "[TEST] order mismatch");
-  }, []);
-
   return { ready, error, openPayForm };
 }


### PR DESCRIPTION
## Summary
- remove leftover console.assert tests from Tinkoff payment widget

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beac6b875c83278b12557af1d765f8