### PR TITLE
Prevent subscription payment without active device

### DIFF
--- a/assets/js/cabinet/app.js
+++ b/assets/js/cabinet/app.js
@@ -66,14 +66,15 @@ export default function AccountApp() {
   }, []);
 
   useEffect(() => {
-    if (!devices.length) {
+    const active = devices.filter((d) => !d.revoked);
+    if (!active.length) {
       setCurrentPremiumDeviceId(null);
-      setCurrentPremiumDeviceName("Нет устройств");
+      setCurrentPremiumDeviceName(devices.length ? "Нет активных устройств" : "Нет устройств");
       setCurrentDeviceIsPremium(false);
       setCurrentDeviceExpiresAt(null);
       return;
     }
-    const last = devices.slice().sort((a, b) => new Date(b.last_seen_at || 0) - new Date(a.last_seen_at || 0))[0];
+    const last = active.slice().sort((a, b) => new Date(b.last_seen_at || 0) - new Date(a.last_seen_at || 0))[0];
     if (last) {
       setCurrentPremiumDeviceId(last.device_id);
       setCurrentPremiumDeviceName(last.model || "Неизвестное устройство");
@@ -150,7 +151,12 @@ export default function AccountApp() {
 
   const handlePay = async () => {
     if (!selectedPlan || !payReady || !currentPremiumDeviceId) {
-      alert(devices.length ? "Не выбрано устройство для подписки." : "У вас нет устройств. Добавьте устройство для оплаты.");
+      const hasDevices = devices.length > 0;
+      const hasActiveDevices = devices.some((d) => !d.revoked);
+      const msg = hasDevices
+        ? (hasActiveDevices ? "Не выбрано устройство для подписки." : "Нет активных устройств. Добавьте устройство для оплаты.")
+        : "У вас нет устройств. Добавьте устройство для оплаты.";
+      alert(msg);
       return;
     }
     const userId = profile?.user_id;

--- a/assets/js/cabinet/panels.js
+++ b/assets/js/cabinet/panels.js
@@ -75,7 +75,21 @@ export function SubscriptionPanel({ onOpenTransfer, currentDeviceName, onPay, pa
         React.createElement("input", { value: email, readOnly: true, className: "rounded-lg border border-slate-200 px-3 py-2 text-sm bg-slate-50 text-slate-700" })
       ),
       React.createElement("div", { className: "mt-4 flex gap-3" },
-        React.createElement("button", { disabled: !payReady || !selectedPlanId || !currentDeviceId, onClick: onPay, className: `rounded-xl px-4 py-2 font-medium text-white ${payReady ? "bg-indigo-600 hover:bg-indigo-700" : "bg-slate-400 cursor-not-allowed"}` }, isPremium ? "Продлить" : "Купить"),
+        (() => {
+          const disabled = !payReady || !selectedPlanId || !currentDeviceId;
+          const cls = disabled
+            ? "bg-slate-400 cursor-not-allowed"
+            : "bg-indigo-600 hover:bg-indigo-700";
+          return React.createElement(
+            "button",
+            {
+              disabled,
+              onClick: onPay,
+              className: `rounded-xl px-4 py-2 font-medium text-white ${cls}`
+            },
+            isPremium ? "Продлить" : "Купить"
+          );
+        })(),
         React.createElement("button", { onClick: onOpenTransfer, className: "rounded-xl border border-slate-200 px-4 py-2 font-medium" }, "Сменить устройство")
       ),
       !payReady && React.createElement("div", { className: "mt-2 text-xs text-slate-500" }, "Загружаем виджет оплаты…")


### PR DESCRIPTION
## Summary
- avoid selecting revoked devices for Premium subscription
- show proper alerts when no device or no active devices before payment
- disable payment button when no active device is available

## Testing
- `npm test` *(fails: enoent Could not read package.json: Error: ENOENT: no such file or directory, open '/workspace/gluone.ru/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68becf40e838832786927f3b82527296