### PR TITLE
feat: add dark theme for cabinet

### DIFF
--- a/assets/js/cabinet/app.js
+++ b/assets/js/cabinet/app.js
@@ -244,7 +244,7 @@ export default function AccountApp() {
     setTransferContext(null);
   };
 
-  return React.createElement("div", { className: "min-h-screen w-full bg-slate-50 flex flex-col" },
+  return React.createElement("div", { className: "min-h-screen w-full bg-slate-50 flex flex-col dark:bg-slate-950 dark:text-slate-100" },
     React.createElement(SiteHeader, { isAuthed, onLogout: handleLogout, userName: profile?.username || profile?.email }),
 
     React.createElement(TransferPremiumModal, {
@@ -269,12 +269,16 @@ export default function AccountApp() {
             { key: "subscription", label: "Подписка" },
             { key: "security", label: "Безопасность" },
             { key: "devices", label: "Устройства" }
-          ].map((t) =>
-            React.createElement("button", {
-              key: t.key, onClick: () => setSection(t.key),
-              className: `rounded-lg px-3 py-2 text-sm border ${section === t.key ? "bg-white border-slate-300" : "bg-slate-100 border-transparent"}`
-            }, t.label)
-          )
+            ].map((t) =>
+              React.createElement("button", {
+                key: t.key, onClick: () => setSection(t.key),
+                className: `rounded-lg px-3 py-2 text-sm border ${
+                  section === t.key
+                    ? "bg-white dark:bg-slate-800 border-slate-300 dark:border-slate-600 text-slate-800 dark:text-slate-200"
+                    : "bg-slate-100 dark:bg-slate-700 border-transparent text-slate-700 dark:text-slate-300"
+                }`
+              }, t.label)
+            )
         ),
         /* показываем панели по секциям */
         section === "profile" && React.createElement(ProfilePanel, { profile, hiddenStatus: true }),
@@ -301,13 +305,13 @@ export default function AccountApp() {
       )
     ),
 
-    React.createElement("footer", { className: "mt-auto border-t border-slate-200 bg-white" },
-      React.createElement("div", { className: "mx-auto max-w-screen-2xl px-5 py-6 text-sm text-slate-500 flex flex-wrap items-center justify-between gap-3" },
+    React.createElement("footer", { className: "mt-auto border-t border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900" },
+      React.createElement("div", { className: "mx-auto max-w-screen-2xl px-5 py-6 text-sm text-slate-500 dark:text-slate-400 flex flex-wrap items-center justify-between gap-3" },
         React.createElement("div", null, "© ", (new Date()).getFullYear(), " GluOne. Все права защищены."),
         React.createElement("div", { className: "flex items-center gap-4" },
-          React.createElement("a", { className: "hover:text-slate-700", href: "#" }, "Политика конфиденциальности"),
-          React.createElement("a", { className: "hover:text-slate-700", href: "#" }, "Условия"),
-          React.createElement("a", { className: "hover:text-slate-700", href: "#" }, "Контакты")
+          React.createElement("a", { className: "hover:text-slate-700 dark:hover:text-slate-200", href: "#" }, "Политика конфиденциальности"),
+          React.createElement("a", { className: "hover:text-slate-700 dark:hover:text-slate-200", href: "#" }, "Условия"),
+          React.createElement("a", { className: "hover:text-slate-700 dark:hover:text-slate-200", href: "#" }, "Контакты")
         )
       )
     )

--- a/assets/js/cabinet/devices.js
+++ b/assets/js/cabinet/devices.js
@@ -14,25 +14,25 @@ export function DeviceItem({ device, onRevoke, onDelete, disableDelete }) {
   const revoked = !!device?.revoked;
   const deviceId = device?.device_id;
 
-  return React.createElement(
-    "div",
-    { className: "rounded-xl border border-slate-200 p-4 bg-white" },
-    React.createElement(
+    return React.createElement(
       "div",
-      { className: "flex items-start justify-between" },
-      React.createElement("div", { className: "font-semibold text-slate-800" }, name),
+      { className: "rounded-xl border border-slate-200 p-4 bg-white dark:bg-slate-800 dark:border-slate-700" },
       React.createElement(
-        "span",
-        {
-          className: `text-xs px-2 py-0.5 rounded-full border ${
-            revoked
-              ? "text-slate-600 bg-slate-50 border-slate-200"
-              : "text-emerald-700 bg-emerald-50 border-emerald-200"
-          }`,
-        },
-        revoked ? "Отозвано" : "Активно"
-      )
-    ),
+        "div",
+        { className: "flex items-start justify-between" },
+        React.createElement("div", { className: "font-semibold text-slate-800 dark:text-slate-100" }, name),
+        React.createElement(
+          "span",
+          {
+            className: `text-xs px-2 py-0.5 rounded-full border ${
+              revoked
+                ? "text-slate-600 bg-slate-50 border-slate-200 dark:text-slate-400 dark:bg-slate-700 dark:border-slate-600"
+                : "text-emerald-700 bg-emerald-50 border-emerald-200 dark:text-emerald-200 dark:bg-emerald-900 dark:border-emerald-700"
+            }`,
+          },
+          revoked ? "Отозвано" : "Активно"
+        )
+      ),
 
     // Блок атрибутов: широкая правая колонка
     React.createElement(
@@ -41,56 +41,58 @@ export function DeviceItem({ device, onRevoke, onDelete, disableDelete }) {
         className:
           "mt-3 grid grid-cols-[minmax(140px,220px)_1fr] gap-x-6 gap-y-2 text-sm",
       },
-      React.createElement("div", { className: "text-slate-500" }, "OC"),
-      React.createElement("div", { className: "text-slate-800 break-words" }, os),
+        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "OC"),
+        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, os),
 
-      React.createElement("div", { className: "text-slate-500" }, "Сборка"),
-      React.createElement("div", { className: "text-slate-800 break-words" }, build),
+        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Сборка"),
+        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, build),
 
-      React.createElement("div", { className: "text-slate-500" }, "Активность"),
-      React.createElement("div", { className: "text-slate-800 break-words" }, active),
+        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Активность"),
+        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, active),
 
-      React.createElement("div", { className: "text-slate-500" }, "Создано"),
-      React.createElement("div", { className: "text-slate-800 break-words" }, created),
+        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Создано"),
+        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, created),
 
-      React.createElement("div", { className: "text-slate-500" }, "IP"),
-      React.createElement("div", { className: "text-slate-800 break-words" }, ip),
+        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "IP"),
+        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, ip),
 
-      React.createElement("div", { className: "text-slate-500" }, "Премиум"),
-      React.createElement("div", { className: "text-slate-800 break-words" }, isPremium ? "Активен" : "Нет"),
+        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Премиум"),
+        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, isPremium ? "Активен" : "Нет"),
 
-      React.createElement("div", { className: "text-slate-500" }, "Действует до"),
-      React.createElement("div", { className: "text-slate-800 break-words" }, isPremium ? premiumUntil : "—"),
+        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Действует до"),
+        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, isPremium ? premiumUntil : "—"),
 
-      React.createElement("div", { className: "text-slate-500" }, "ID устройства"),
-      React.createElement("div", { className: "text-slate-800 break-words" }, deviceId)
-    ),
+        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "ID устройства"),
+        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, deviceId)
+      ),
 
-    React.createElement(
-      "div",
-      { className: "mt-3 flex justify-end gap-2" },
-      !revoked
-        ? React.createElement(
-            "button",
-            {
-              className:
-                "rounded-lg bg-slate-900 text-white px-3 py-1.5 text-sm hover:bg-slate-800",
-              onClick: () => onRevoke(deviceId),
-            },
-            "Выйти с устройства"
-          )
-        : React.createElement(
-            "button",
-            {
-              className: `rounded-lg px-3 py-1.5 text-sm text-white ${
-                disableDelete ? "bg-slate-400 cursor-not-allowed" : "bg-rose-600 hover:bg-rose-700"
-              }`,
-              disabled: disableDelete,
-              onClick: () => onDelete(deviceId),
-            },
-            "Удалить"
-          )
-    )
+      React.createElement(
+        "div",
+        { className: "mt-3 flex justify-end gap-2" },
+        !revoked
+          ? React.createElement(
+              "button",
+              {
+                className:
+                  "rounded-lg bg-slate-900 text-white px-3 py-1.5 text-sm hover:bg-slate-800 dark:bg-slate-700 dark:hover:bg-slate-600",
+                onClick: () => onRevoke(deviceId),
+              },
+              "Выйти с устройства"
+            )
+          : React.createElement(
+              "button",
+              {
+                className: `rounded-lg px-3 py-1.5 text-sm text-white ${
+                  disableDelete
+                    ? "bg-slate-400 cursor-not-allowed dark:bg-slate-600"
+                    : "bg-rose-600 hover:bg-rose-700"
+                }`,
+                disabled: disableDelete,
+                onClick: () => onDelete(deviceId),
+              },
+              "Удалить"
+            )
+      )
   );
 }
 
@@ -113,66 +115,68 @@ export function TransferPremiumModal({
   const eligible = devices.filter((d) => !d.revoked);
   const chosen = eligible.find((x) => x.deviceId === selected);
 
-  return React.createElement(
-    "div",
-    { className: "fixed inset-0 z-50 flex items-center justify-center" },
-    React.createElement("div", { className: "absolute inset-0 bg-slate-900/40", onClick: onClose }),
-    React.createElement(
+    return React.createElement(
       "div",
-      { className: "relative w-full max-w-lg rounded-2xl bg-white shadow-xl border border-slate-200 p-4" },
-      React.createElement("div", { className: "text-base font-semibold text-slate-900" }, title || "Выбрать устройство для оплаты"),
-      React.createElement("p", { className: "mt-1 text-sm text-slate-600" }, description || "Выберите устройство из списка."),
+      { className: "fixed inset-0 z-50 flex items-center justify-center" },
+      React.createElement("div", { className: "absolute inset-0 bg-slate-900/40", onClick: onClose }),
       React.createElement(
         "div",
-        { className: "mt-4 space-y-2 max-h-72 overflow-auto" },
-        eligible.length === 0 &&
-          React.createElement("div", { className: "text-sm text-slate-500" }, "Нет доступных устройств."),
-        eligible.map((d) =>
-          React.createElement(
-            "label",
-            { key: d.deviceId, className: "flex items-start gap-3 rounded-xl border border-slate-200 p-3 hover:bg-slate-50 cursor-pointer" },
-            React.createElement("input", {
-              type: "radio",
-              name: "transfer-device",
-              className: "mt-1",
-              checked: selected === d.deviceId,
-              onChange: () => setSelected(d.deviceId),
-            }),
+        { className: "relative w-full max-w-lg rounded-2xl bg-white shadow-xl border border-slate-200 p-4 dark:bg-slate-800 dark:border-slate-700" },
+        React.createElement("div", { className: "text-base font-semibold text-slate-900 dark:text-slate-100" }, title || "Выбрать устройство для оплаты"),
+        React.createElement("p", { className: "mt-1 text-sm text-slate-600 dark:text-slate-400" }, description || "Выберите устройство из списка."),
+        React.createElement(
+          "div",
+          { className: "mt-4 space-y-2 max-h-72 overflow-auto" },
+          eligible.length === 0 &&
+            React.createElement("div", { className: "text-sm text-slate-500 dark:text-slate-400" }, "Нет доступных устройств."),
+          eligible.map((d) =>
             React.createElement(
-              "div",
-              { className: "flex-1" },
-              React.createElement("div", { className: "font-medium text-slate-800" }, d.name),
-              React.createElement("div", { className: "text-xs text-slate-500" }, `${d.os || "—"} • ${d.ip} • ${d.active}`)
+              "label",
+              { key: d.deviceId, className: "flex items-start gap-3 rounded-xl border border-slate-200 p-3 hover:bg-slate-50 cursor-pointer dark:border-slate-700 dark:hover:bg-slate-700" },
+              React.createElement("input", {
+                type: "radio",
+                name: "transfer-device",
+                className: "mt-1",
+                checked: selected === d.deviceId,
+                onChange: () => setSelected(d.deviceId),
+              }),
+              React.createElement(
+                "div",
+                { className: "flex-1" },
+                React.createElement("div", { className: "font-medium text-slate-800 dark:text-slate-100" }, d.name),
+                React.createElement("div", { className: "text-xs text-slate-500 dark:text-slate-400" }, `${d.os || "—"} • ${d.ip} • ${d.active}`)
+              )
             )
           )
-        )
-      ),
-      sourceName &&
-        selected &&
-        React.createElement(
-          "p",
-          { className: "mt-2 text-sm text-slate-600" },
-          `Премиум будет перенесён с устройства "${sourceName}" на "${chosen?.name || ""}".`
         ),
-      React.createElement(
-        "div",
-        { className: "mt-4 flex justify-end gap-2" },
-        React.createElement("button", { className: "rounded-lg border border-slate-200 px-3 py-1.5 text-sm", onClick: onClose }, "Отмена"),
+        sourceName &&
+          selected &&
+          React.createElement(
+            "p",
+            { className: "mt-2 text-sm text-slate-600 dark:text-slate-400" },
+            `Премиум будет перенесён с устройства "${sourceName}" на "${chosen?.name || ""}".`
+          ),
         React.createElement(
-          "button",
-          {
-            disabled: !selected,
-            className: `rounded-lg px-3 py-1.5 text-sm text-white ${
-              selected ? "bg-indigo-600 hover:bg-indigo-700" : "bg-slate-400 cursor-not-allowed"
-            }`,
-            onClick: () => {
-              const d = eligible.find((x) => x.deviceId === selected);
-              if (d) onConfirm(d);
+          "div",
+          { className: "mt-4 flex justify-end gap-2" },
+          React.createElement("button", { className: "rounded-lg border border-slate-200 px-3 py-1.5 text-sm dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100", onClick: onClose }, "Отмена"),
+          React.createElement(
+            "button",
+            {
+              disabled: !selected,
+              className: `rounded-lg px-3 py-1.5 text-sm text-white ${
+                selected
+                  ? "bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600"
+                  : "bg-slate-400 cursor-not-allowed dark:bg-slate-600"
+              }`,
+              onClick: () => {
+                const d = eligible.find((x) => x.deviceId === selected);
+                if (d) onConfirm(d);
+              },
             },
-          },
-          "Выбрать"
+            "Выбрать"
+          )
         )
       )
-    )
-  );
-}
+    );
+  }

--- a/assets/js/cabinet/layout.js
+++ b/assets/js/cabinet/layout.js
@@ -8,44 +8,52 @@ export function UserMenu({ isAuthed, userName = "", onLogout }) {
     if (!isAuthed) { window.location.href = "https://gluone.ru/auth.html"; return; }
     setOpen((v) => !v);
   };
-  return React.createElement("div", { className: "relative" },
-    React.createElement("button", {
-      onClick: handleClick,
-      "aria-haspopup": isAuthed ? "menu" : void 0,
-      "aria-expanded": open,
-      className: `flex items-center justify-center rounded-full h-9 ${isAuthed ? "w-9 bg-slate-100 text-slate-800 hover:bg-slate-200" : "px-3 bg-slate-100 text-slate-900 hover:bg-slate-200 rounded-full"} border border-slate-200 text-sm font-medium`,
-      title: isAuthed ? "Аккаунт" : "Войти"
-    }, isAuthed ? React.createElement("span", { className: "font-semibold" }, initial) : React.createElement("span", null, "Войти")),
-    isAuthed && open && React.createElement("div", { role: "menu", className: "absolute right-0 mt-2 w-44 rounded-xl border border-slate-200 bg-white shadow-lg py-1" },
-      React.createElement("div", { className: "px-3 py-2 text-xs text-slate-500" }, userName),
-      React.createElement("button", { onClick: () => { setOpen(false); onLogout(); }, className: "w-full text-left px-3 py-2 text-sm hover:bg-slate-50" }, "Выйти")
-    )
-  );
-}
-
-export function SiteHeader({ isAuthed, onLogout, userName }) {
-  return React.createElement("header", { className: "sticky top-0 z-40 w-full border-b border-slate-200 bg-white/90 backdrop-blur" },
-    React.createElement("div", { className: "mx-auto max-w-screen-2xl px-5 h-14 flex items-center justify-between" },
-      React.createElement("div", { className: "flex items-center gap-3" },
-        React.createElement("img", { src: "assets/image/logo.png", className: "h-9 w-9 rounded-xl", alt: "GluOne logo", width: "36", height: "36" }),
-        React.createElement("span", { className: "font-semibold text-slate-900" }, "GluOne")
-      ),
-      React.createElement("nav", { className: "hidden md:flex items-center gap-6 text-sm text-slate-600" },
-        React.createElement("a", { className: "hover:text-slate-900", href: "https://gluone.ru" }, "Главная"),
-        React.createElement("a", { className: "hover:text-slate-900", href: "#" }, "Поддержка")
-      ),
-      React.createElement("div", { className: "flex items-center gap-3" },
-        React.createElement(UserMenu, { isAuthed, userName, onLogout })
+    return React.createElement("div", { className: "relative" },
+      React.createElement("button", {
+        onClick: handleClick,
+        "aria-haspopup": isAuthed ? "menu" : void 0,
+        "aria-expanded": open,
+        className: `flex items-center justify-center rounded-full h-9 ${
+          isAuthed
+            ? "w-9 bg-slate-100 text-slate-800 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+            : "px-3 bg-slate-100 text-slate-900 hover:bg-slate-200 rounded-full dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+        } border border-slate-200 dark:border-slate-700 text-sm font-medium`,
+        title: isAuthed ? "Аккаунт" : "Войти"
+      }, isAuthed ? React.createElement("span", { className: "font-semibold" }, initial) : React.createElement("span", null, "Войти")),
+      isAuthed && open && React.createElement("div", { role: "menu", className: "absolute right-0 mt-2 w-44 rounded-xl border border-slate-200 bg-white shadow-lg py-1 dark:border-slate-700 dark:bg-slate-800" },
+        React.createElement("div", { className: "px-3 py-2 text-xs text-slate-500 dark:text-slate-400" }, userName),
+        React.createElement("button", { onClick: () => { setOpen(false); onLogout(); }, className: "w-full text-left px-3 py-2 text-sm hover:bg-slate-50 dark:hover:bg-slate-700" }, "Выйти")
       )
-    )
-  );
-}
+    );
+  }
+
+  export function SiteHeader({ isAuthed, onLogout, userName }) {
+    return React.createElement("header", { className: "sticky top-0 z-40 w-full border-b border-slate-200 bg-white/90 backdrop-blur dark:border-slate-700 dark:bg-slate-900/90" },
+      React.createElement("div", { className: "mx-auto max-w-screen-2xl px-5 h-14 flex items-center justify-between" },
+        React.createElement("div", { className: "flex items-center gap-3" },
+          React.createElement("img", { src: "assets/image/logo.png", className: "h-9 w-9 rounded-xl", alt: "GluOne logo", width: "36", height: "36" }),
+          React.createElement("span", { className: "font-semibold text-slate-900 dark:text-slate-100" }, "GluOne")
+        ),
+        React.createElement("nav", { className: "hidden md:flex items-center gap-6 text-sm text-slate-600 dark:text-slate-400" },
+          React.createElement("a", { className: "hover:text-slate-900 dark:hover:text-slate-100", href: "https://gluone.ru" }, "Главная"),
+          React.createElement("a", { className: "hover:text-slate-900 dark:hover:text-slate-100", href: "#" }, "Поддержка")
+        ),
+        React.createElement("div", { className: "flex items-center gap-3" },
+          React.createElement(UserMenu, { isAuthed, userName, onLogout })
+        )
+      )
+    );
+  }
 
 export function Sidebar({ current, onChange }) {
-  const Item = ({ k, label, icon }) => React.createElement("button", {
-    onClick: () => onChange(k),
-    className: `w-full flex items-center gap-2 rounded-xl px-3 py-2 text-sm ${current === k ? "bg-indigo-50 text-indigo-700" : "hover:bg-slate-50 text-slate-700"}`
-  }, React.createElement("span", { className: "text-base" }, icon), React.createElement("span", { className: "font-medium" }, label));
+    const Item = ({ k, label, icon }) => React.createElement("button", {
+      onClick: () => onChange(k),
+      className: `w-full flex items-center gap-2 rounded-xl px-3 py-2 text-sm ${
+        current === k
+          ? "bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-100"
+          : "hover:bg-slate-50 text-slate-700 dark:hover:bg-slate-700 dark:text-slate-300"
+      }`
+    }, React.createElement("span", { className: "text-base" }, icon), React.createElement("span", { className: "font-medium" }, label));
   return React.createElement("aside", { className: "hidden xl:block w-64 shrink-0" },
     React.createElement("div", { className: "sticky top-16 space-y-1" },
       React.createElement(Item, { k: "profile", label: "Профиль", icon: "👤" }),

--- a/assets/js/cabinet/panels.js
+++ b/assets/js/cabinet/panels.js
@@ -15,25 +15,25 @@ export function ProfilePanel({ profile, hiddenStatus = true }) {
   const roles = Array.isArray(profile.roles) ? profile.roles : [];
   return React.createElement("div", { className: "space-y-4 w-full" },
     React.createElement(SectionCard, null,
-      React.createElement("div", { className: "flex items-center gap-3" },
-        React.createElement("div", { className: "h-12 w-12 shrink-0 rounded-xl bg-indigo-100 text-indigo-600 font-semibold flex items-center justify-center" }, initial),
-        React.createElement("div", { className: "flex-1" },
-          React.createElement("div", { className: "flex items-center gap-2 flex-wrap" },
-            React.createElement("div", { className: "font-semibold text-slate-900" }, profile.username || "Без имени"),
-            profile.is_premium && React.createElement(Chip, null, "Premium")
-          ),
-          React.createElement("div", { className: "text-sm text-slate-500" }, profile.email ? maskEmail(profile.email) : "—")
-        )
-      ),
+        React.createElement("div", { className: "flex items-center gap-3" },
+          React.createElement("div", { className: "h-12 w-12 shrink-0 rounded-xl bg-indigo-100 text-indigo-600 font-semibold flex items-center justify-center" }, initial),
+          React.createElement("div", { className: "flex-1" },
+            React.createElement("div", { className: "flex items-center gap-2 flex-wrap" },
+              React.createElement("div", { className: "font-semibold text-slate-900 dark:text-slate-100" }, profile.username || "Без имени"),
+              profile.is_premium && React.createElement(Chip, null, "Premium")
+            ),
+            React.createElement("div", { className: "text-sm text-slate-500 dark:text-slate-400" }, profile.email ? maskEmail(profile.email) : "—")
+          )
+        ),
       React.createElement("div", { className: "mt-4" },
-        !hiddenStatus && React.createElement("div", { className: "flex items-center justify-between py-1.5" },
-          React.createElement("div", { className: "text-sm text-slate-500" }, "Статус"),
-          React.createElement("span", { className: profile.is_active ? "text-emerald-700" : "text-rose-600" }, profile.is_active ? "Активен" : "Неактивен")
-        ),
-        React.createElement("div", { className: "flex items-center justify-between py-1.5" },
-          React.createElement("div", { className: "text-sm text-slate-500" }, "Роли"),
-          React.createElement("div", { className: "flex flex-wrap gap-1 justify-end" }, roles.map((r) => React.createElement(Chip, { key: r }, r)))
-        ),
+          !hiddenStatus && React.createElement("div", { className: "flex items-center justify-between py-1.5" },
+            React.createElement("div", { className: "text-sm text-slate-500 dark:text-slate-400" }, "Статус"),
+            React.createElement("span", { className: profile.is_active ? "text-emerald-700" : "text-rose-600" }, profile.is_active ? "Активен" : "Неактивен")
+          ),
+          React.createElement("div", { className: "flex items-center justify-between py-1.5" },
+            React.createElement("div", { className: "text-sm text-slate-500 dark:text-slate-400" }, "Роли"),
+            React.createElement("div", { className: "flex flex-wrap gap-1 justify-end" }, roles.map((r) => React.createElement(Chip, { key: r }, r)))
+          ),
         React.createElement(KeyRow, { label: "Пол", value: mapGender(profile.gender) }),
         React.createElement(KeyRow, { label: "Дата рождения", value: profile.birth_date ? `${fmtDate(profile.birth_date)}${ageFrom(profile.birth_date) ? ` • ${ageFrom(profile.birth_date)} лет` : ""}` : "—" }),
         React.createElement(KeyRow, { label: "Тип диабета", value: mapDia(profile.diabetes_type) })
@@ -46,51 +46,51 @@ export function ProfilePanel({ profile, hiddenStatus = true }) {
 export function SubscriptionPanel({ onOpenTransfer, currentDeviceName, onPay, plans, selectedPlanId, setSelectedPlanId, amountRub, monthPrice, email, currentDeviceId, isPremium, premiumExpiresAt }) {
   return React.createElement("div", { className: "w-full" },
     React.createElement(SectionCard, { title: "Подписка Premium" },
-      React.createElement("div", { className: "space-y-2 text-sm" },
-        React.createElement("div", { className: "flex items-center justify-between" },
-          React.createElement("span", { className: "text-slate-500" }, "Статус"),
-          React.createElement("span", { className: `font-medium ${isPremium ? "text-emerald-700" : "text-rose-600"}` }, isPremium ? "Активна" : "Неактивна")
+        React.createElement("div", { className: "space-y-2 text-sm" },
+          React.createElement("div", { className: "flex items-center justify-between" },
+            React.createElement("span", { className: "text-slate-500 dark:text-slate-400" }, "Статус"),
+            React.createElement("span", { className: `font-medium ${isPremium ? "text-emerald-700" : "text-rose-600"}` }, isPremium ? "Активна" : "Неактивна")
+          ),
+          isPremium && React.createElement("div", { className: "flex items-center justify-between" },
+            React.createElement("span", { className: "text-slate-500 dark:text-slate-400" }, "Действует до"),
+            React.createElement("span", { className: "font-medium" }, fmtDate(premiumExpiresAt))
+          ),
+          React.createElement("div", { className: "flex items-center justify-between" },
+            React.createElement("span", { className: "text-slate-500 dark:text-slate-400" }, "Устройство"),
+            React.createElement("span", { className: "font-medium" }, currentDeviceName)
+          )
         ),
-        isPremium && React.createElement("div", { className: "flex items-center justify-between" },
-          React.createElement("span", { className: "text-slate-500" }, "Действует до"),
-          React.createElement("span", { className: "font-medium" }, fmtDate(premiumExpiresAt))
+        React.createElement("div", { className: "mt-4 grid grid-cols-1 md:grid-cols-[1fr_auto] gap-3 items-end" },
+          React.createElement("div", { className: "flex flex-col gap-1" },
+            React.createElement("label", { className: "text-sm text-slate-600 dark:text-slate-400" }, "Период оплаты"),
+            React.createElement("select", {
+              value: selectedPlanId,
+              onChange: (e) => setSelectedPlanId(e.target.value),
+              className: "rounded-lg border border-slate-200 px-4 py-3 text-base outline-none focus:ring-2 focus:ring-indigo-100 bg-white dark:bg-slate-800 dark:border-slate-600"
+            }, plans.map((p) => React.createElement("option", { key: p.id, value: p.id }, `${p.duration_months} мес. — ${formatRub(p.price)} ₽`)))
+          ),
+          React.createElement("div", { className: "text-right" },
+            React.createElement("div", { className: "text-xs text-slate-500 dark:text-slate-400" }, "Итого к оплате"),
+            React.createElement("div", { className: "text-2xl font-extrabold text-slate-900 leading-none dark:text-slate-100" }, formatRub(amountRub), " ₽"),
+            selectedPlanId && React.createElement("div", { className: "text-xs text-slate-500 mt-1 dark:text-slate-400" }, `${formatRub(monthPrice)} ₽/мес× ${plans.find((p) => p.id === selectedPlanId)?.duration_months}`)
+          )
         ),
-        React.createElement("div", { className: "flex items-center justify-between" },
-          React.createElement("span", { className: "text-slate-500" }, "Устройство"),
-          React.createElement("span", { className: "font-medium" }, currentDeviceName)
+        // Скрываем E-mail плательщика по требованиям
+        React.createElement("div", { className: "mt-5 flex gap-3" },
+          (() => {
+            const disabled = !selectedPlanId || !currentDeviceId;
+            const cls = disabled ? "bg-slate-400 cursor-not-allowed dark:bg-slate-600" : "bg-indigo-600 hover:bg-indigo-700";
+            return React.createElement(
+              "button",
+              { disabled, onClick: onPay, className: `rounded-xl px-5 py-3 font-semibold text-white text-base ${cls}` },
+              isPremium ? "Продлить" : "Купить"
+            );
+          })(),
+          React.createElement("button", { onClick: onOpenTransfer, className: "rounded-xl border border-slate-200 px-5 py-3 font-semibold text-base bg-white hover:bg-slate-50 dark:bg-slate-800 dark:border-slate-600 dark:hover:bg-slate-700" }, "Сменить устройство")
         )
-      ),
-      React.createElement("div", { className: "mt-4 grid grid-cols-1 md:grid-cols-[1fr_auto] gap-3 items-end" },
-        React.createElement("div", { className: "flex flex-col gap-1" },
-          React.createElement("label", { className: "text-sm text-slate-600" }, "Период оплаты"),
-          React.createElement("select", {
-            value: selectedPlanId,
-            onChange: (e) => setSelectedPlanId(e.target.value),
-            className: "rounded-lg border border-slate-200 px-4 py-3 text-base outline-none focus:ring-2 focus:ring-indigo-100 bg-white"
-          }, plans.map((p) => React.createElement("option", { key: p.id, value: p.id }, `${p.duration_months} мес. — ${formatRub(p.price)} ₽`)))
-        ),
-        React.createElement("div", { className: "text-right" },
-          React.createElement("div", { className: "text-xs text-slate-500" }, "Итого к оплате"),
-          React.createElement("div", { className: "text-2xl font-extrabold text-slate-900 leading-none" }, formatRub(amountRub), " ₽"),
-          selectedPlanId && React.createElement("div", { className: "text-xs text-slate-500 mt-1" }, `${formatRub(monthPrice)} ₽/мес× ${plans.find((p) => p.id === selectedPlanId)?.duration_months}`)
-        )
-      ),
-      // Скрываем E-mail плательщика по требованиям
-      React.createElement("div", { className: "mt-5 flex gap-3" },
-        (() => {
-          const disabled = !selectedPlanId || !currentDeviceId;
-          const cls = disabled ? "bg-slate-400 cursor-not-allowed" : "bg-indigo-600 hover:bg-indigo-700";
-          return React.createElement(
-            "button",
-            { disabled, onClick: onPay, className: `rounded-xl px-5 py-3 font-semibold text-white text-base ${cls}` },
-            isPremium ? "Продлить" : "Купить"
-          );
-        })(),
-        React.createElement("button", { onClick: onOpenTransfer, className: "rounded-xl border border-slate-200 px-5 py-3 font-semibold text-base bg-white hover:bg-slate-50" }, "Сменить устройство")
       )
-    )
-  );
-}
+    );
+  }
 
 /* ===================== Безопасность ===================== */
 function DeleteAccountModal({ open, onClose, onSubmit, defaultLogin = "" }) {
@@ -109,40 +109,40 @@ function DeleteAccountModal({ open, onClose, onSubmit, defaultLogin = "" }) {
 
   return React.createElement("div", { className: "fixed inset-0 z-50 grid place-items-center" },
     React.createElement("div", { className: "absolute inset-0 bg-slate-900/40", onClick: onClose }),
-    React.createElement("div", { className: "relative w-[min(520px,96vw)] rounded-2xl bg-white shadow-2xl border border-slate-200 p-6" },
-      React.createElement("div", { className: "text-xl font-bold text-slate-900" }, "Удаление аккаунта"),
-      React.createElement("p", { className: "mt-1 text-sm text-slate-600" }, "Подтвердите удаление — укажите логин и пароль. Действие нельзя отменить."),
+    React.createElement("div", { className: "relative w-[min(520px,96vw)] rounded-2xl bg-white shadow-2xl border border-slate-200 p-6 dark:bg-slate-800 dark:border-slate-700" },
+      React.createElement("div", { className: "text-xl font-bold text-slate-900 dark:text-slate-100" }, "Удаление аккаунта"),
+      React.createElement("p", { className: "mt-1 text-sm text-slate-600 dark:text-slate-400" }, "Подтвердите удаление — укажите логин и пароль. Действие нельзя отменить."),
       React.createElement("div", { className: "mt-4 grid gap-3" },
         React.createElement("div", { className: "flex flex-col gap-1" },
-          React.createElement("label", { className: "text-sm text-slate-700" }, "Логин"),
+          React.createElement("label", { className: "text-sm text-slate-700 dark:text-slate-300" }, "Логин"),
           React.createElement("input", {
             value: login, onChange: (e) => setLogin(e.target.value),
             autoComplete: "username",
-            className: "w-full rounded-xl border border-slate-300 px-4 h-12 text-base outline-none focus:ring-2 focus:ring-indigo-100 bg-white"
+            className: "w-full rounded-xl border border-slate-300 dark:border-slate-600 px-4 h-12 text-base outline-none focus:ring-2 focus:ring-indigo-100 bg-white dark:bg-slate-800 dark:border-slate-600"
           })
         ),
         React.createElement("div", { className: "flex flex-col gap-1" },
-          React.createElement("label", { className: "text-sm text-slate-700" }, "Пароль"),
+          React.createElement("label", { className: "text-sm text-slate-700 dark:text-slate-300" }, "Пароль"),
           React.createElement("div", { className: "relative" },
             React.createElement("input", {
               type: showPass ? "text" : "password",
               value: pass, onChange: (e) => setPass(e.target.value),
               autoComplete: "current-password",
-              className: "w-full rounded-xl border border-slate-300 px-4 h-12 text-base outline-none focus:ring-2 focus:ring-indigo-100 bg-white pr-12"
+              className: "w-full rounded-xl border border-slate-300 dark:border-slate-600 px-4 h-12 text-base outline-none focus:ring-2 focus:ring-indigo-100 bg-white pr-12 dark:bg-slate-800 dark:border-slate-600"
             }),
             React.createElement("button", {
               type: "button",
               onClick: () => setShowPass(v => !v),
               "aria-label": showPass ? "Скрыть пароль" : "Показать пароль",
               title: showPass ? "Скрыть пароль" : "Показать пароль",
-              className: "absolute right-2 top-1/2 -translate-y-1/2 h-9 w-9 grid place-items-center rounded-lg text-slate-500 hover:bg-slate-100"
+              className: "absolute right-2 top-1/2 -translate-y-1/2 h-9 w-9 grid place-items-center rounded-lg text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700"
             }, showPass ? "🙈" : "👁️")
           )
         ),
         error && React.createElement("div", { className: "text-sm text-rose-600" }, error)
       ),
       React.createElement("div", { className: "mt-5 flex justify-end gap-2" },
-        React.createElement("button", { onClick: onClose, className: "rounded-lg border border-slate-200 px-4 h-11 text-sm bg-white hover:bg-slate-50" }, "Отмена"),
+        React.createElement("button", { onClick: onClose, className: "rounded-lg border border-slate-200 px-4 h-11 text-sm bg-white hover:bg-slate-50 dark:bg-slate-800 dark:border-slate-600 dark:hover:bg-slate-700" }, "Отмена"),
         React.createElement("button", { onClick: submit, className: "rounded-lg bg-rose-600 text-white px-4 h-11 text-sm font-semibold hover:bg-rose-700" }, "Удалить")
       )
     )
@@ -169,10 +169,10 @@ export function SecurityPanel({ username, onChangePassword, onDeleteAccount }) {
   return React.createElement("div", { className: "space-y-6 w-full" },
     React.createElement(SectionCard, { title: "Смена пароля" },
       React.createElement("form", { className: "space-y-5", onSubmit: handleSubmit },
-        React.createElement("p", { className: "text-base text-slate-600" }, "Рекомендуем менять пароль раз в 6–12 месяцев."),
+        React.createElement("p", { className: "text-base text-slate-600 dark:text-slate-400" }, "Рекомендуем менять пароль раз в 6–12 месяцев."),
         React.createElement("div", { className: "grid grid-cols-1 md:grid-cols-2 gap-4" },
           React.createElement("div", { className: "flex flex-col gap-2" },
-            React.createElement("label", { className: "text-base font-medium text-slate-700" }, "Текущий пароль"),
+            React.createElement("label", { className: "text-base font-medium text-slate-700 dark:text-slate-300" }, "Текущий пароль"),
             React.createElement("div", { className: "relative" },
               React.createElement("input", {
                 type: showOld ? "text" : "password",
@@ -180,19 +180,19 @@ export function SecurityPanel({ username, onChangePassword, onDeleteAccount }) {
                 value: oldPass,
                 onChange: (e) => setOldPass(e.target.value),
                 placeholder: "Введите текущий пароль",
-                className: "w-full rounded-xl border border-slate-300 px-4 h-14 text-base outline-none focus:ring-2 focus:ring-indigo-100 bg-white pr-12"
+                className: "w-full rounded-xl border border-slate-300 dark:border-slate-600 px-4 h-14 text-base outline-none focus:ring-2 focus:ring-indigo-100 bg-white dark:bg-slate-800 pr-12"
               }),
               React.createElement("button", {
                 type: "button",
                 onClick: () => setShowOld((v) => !v),
                 "aria-label": showOld ? "Скрыть пароль" : "Показать пароль",
                 title: showOld ? "Скрыть пароль" : "Показать пароль",
-                className: "absolute right-2 top-1/2 -translate-y-1/2 h-10 w-10 grid place-items-center rounded-lg text-slate-500 hover:bg-slate-100"
+                className: "absolute right-2 top-1/2 -translate-y-1/2 h-10 w-10 grid place-items-center rounded-lg text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700"
               }, showOld ? "🙈" : "👁️")
             )
           ),
           React.createElement("div", { className: "flex flex-col gap-2" },
-            React.createElement("label", { className: "text-base font-medium text-slate-700" }, "Новый пароль"),
+            React.createElement("label", { className: "text-base font-medium text-slate-700 dark:text-slate-300" }, "Новый пароль"),
             React.createElement("div", { className: "relative" },
               React.createElement("input", {
                 type: showNew ? "text" : "password",
@@ -200,21 +200,21 @@ export function SecurityPanel({ username, onChangePassword, onDeleteAccount }) {
                 value: newPass,
                 onChange: (e) => setNewPass(e.target.value),
                 placeholder: "Введите новый пароль",
-                className: "w-full rounded-xl border border-slate-300 px-4 h-14 text-base outline-none focus:ring-2 focus:ring-indigo-100 bg-white pr-12"
+                className: "w-full rounded-xl border border-slate-300 dark:border-slate-600 px-4 h-14 text-base outline-none focus:ring-2 focus:ring-indigo-100 bg-white dark:bg-slate-800 pr-12"
               }),
               React.createElement("button", {
                 type: "button",
                 onClick: () => setShowNew((v) => !v),
                 "aria-label": showNew ? "Скрыть пароль" : "Показать пароль",
                 title: showNew ? "Скрыть пароль" : "Показать пароль",
-                className: "absolute right-2 top-1/2 -translate-y-1/2 h-10 w-10 grid place-items-center rounded-lg text-slate-500 hover:bg-slate-100"
+                className: "absolute right-2 top-1/2 -translate-y-1/2 h-10 w-10 grid place-items-center rounded-lg text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700"
               }, showNew ? "🙈" : "👁️")
             )
           )
         ),
-        msg && React.createElement("div", { className: "text-base text-slate-600" }, msg),
+        msg && React.createElement("div", { className: "text-base text-slate-600 dark:text-slate-400" }, msg),
         React.createElement("div", { className: "flex items-center justify-end" },
-          React.createElement("button", { disabled: loading, className: "rounded-xl bg-slate-900 text-white px-6 h-12 text-base font-semibold hover:bg-slate-800" }, loading ? "Обновляем…" : "Обновить")
+          React.createElement("button", { disabled: loading, className: "rounded-xl bg-slate-900 text-white px-6 h-12 text-base font-semibold hover:bg-slate-800 dark:bg-slate-700 dark:hover:bg-slate-600" }, loading ? "Обновляем…" : "Обновить")
         )
       )
     ),
@@ -237,7 +237,7 @@ export function SecurityPanel({ username, onChangePassword, onDeleteAccount }) {
 /* ===================== Устройства ===================== */
 export function DevicesPanel({ devices, onRevoke, onDelete }) {
   return React.createElement("div", { className: "space-y-4" },
-    React.createElement(SectionCard, { title: "Устройства", footer: React.createElement("div", { className: "text-sm text-slate-500" }, "Всего устройств: ", devices.length) },
+      React.createElement(SectionCard, { title: "Устройства", footer: React.createElement("div", { className: "text-sm text-slate-500 dark:text-slate-400" }, "Всего устройств: ", devices.length) },
       React.createElement("div", { className: "grid grid-cols-1 md:grid-cols-2 gap-3" },
         devices.map((dev) => {
           const disableDelete = devices.length === 1 && dev.is_premium;

--- a/assets/js/cabinet/ui.js
+++ b/assets/js/cabinet/ui.js
@@ -5,7 +5,7 @@ export function Chip({ children }) {
     "span",
     {
       className:
-        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium bg-white/60 text-slate-700 border-slate-200",
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium bg-white/60 text-slate-700 border-slate-200 dark:bg-slate-700/60 dark:text-slate-200 dark:border-slate-600",
     },
     children
   );
@@ -17,21 +17,21 @@ export function RowButton({ icon, children, onClick }) {
     {
       onClick,
       className:
-        "w-full flex items-center gap-2 rounded-xl px-3 py-2.5 text-sm hover:bg-slate-50 border border-transparent hover:border-slate-200 transition",
+        "w-full flex items-center gap-2 rounded-xl px-3 py-2.5 text-sm hover:bg-slate-50 border border-transparent hover:border-slate-200 transition dark:hover:bg-slate-700 dark:hover:border-slate-600",
     },
-    React.createElement("span", { className: "text-slate-500" }, icon),
-    React.createElement("span", { className: "text-slate-800 font-medium" }, children)
+    React.createElement("span", { className: "text-slate-500 dark:text-slate-400" }, icon),
+    React.createElement("span", { className: "text-slate-800 font-medium dark:text-slate-100" }, children)
   );
 }
 
 export function SectionCard({ title, children, footer }) {
   return React.createElement(
     "div",
-    { className: "w-full rounded-2xl border bg-white shadow-sm border-slate-200" },
+    { className: "w-full rounded-2xl border bg-white shadow-sm border-slate-200 dark:bg-slate-800 dark:border-slate-700" },
     title &&
       React.createElement(
         "div",
-        { className: "px-5 py-4 border-b border-slate-200/60 text-sm font-semibold text-slate-800" },
+        { className: "px-5 py-4 border-b border-slate-200/60 text-sm font-semibold text-slate-800 dark:border-slate-700/60 dark:text-slate-100" },
         title
       ),
     React.createElement("div", { className: "p-5" }, children),
@@ -50,10 +50,10 @@ export function KeyRow({ label, value }) {
     {
       className: "grid grid-cols-[minmax(140px,220px)_1fr] gap-3 items-baseline py-2",
     },
-    React.createElement("div", { className: "text-sm text-slate-500" }, label),
+    React.createElement("div", { className: "text-sm text-slate-500 dark:text-slate-400" }, label),
     React.createElement(
       "div",
-      { className: "text-sm font-medium text-slate-800 break-words" },
+      { className: "text-sm font-medium text-slate-800 break-words dark:text-slate-100" },
       value
     )
   );
@@ -65,7 +65,7 @@ export function DangerLink({ children, onClick }) {
     {
       onClick,
       className:
-        "w-full text-sm font-medium text-rose-600 hover:text-rose-700 px-2 py-2 rounded-lg text-left",
+        "w-full text-sm font-medium text-rose-600 hover:text-rose-700 px-2 py-2 rounded-lg text-left dark:text-rose-400 dark:hover:text-rose-300",
     },
     children
   );

--- a/cabinet.html
+++ b/cabinet.html
@@ -26,11 +26,11 @@
   <!-- Общие скрипты сайта (шапка/прочее) -->
   <script type="module" src="assets/js/core.js"></script>
 </head>
-<body class="bg-slate-50">
+<body class="bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
   <!-- Корневой контейнер приложения -->
   <div id="root">
     <!-- Лёгкий прелоадер, пока грузится React-приложение -->
-    <div class="min-h-screen w-full flex items-center justify-center text-slate-500">
+    <div class="min-h-screen w-full flex items-center justify-center text-slate-500 dark:text-slate-400">
       Загружаем кабинет…
     </div>
   </div>
@@ -39,7 +39,7 @@
   <script type="module" src="assets/js/cabinet.js"></script>
 
   <noscript>
-    <p class="text-center p-3 text-sm text-slate-600">
+    <p class="text-center p-3 text-sm text-slate-600 dark:text-slate-400">
       Для работы личного кабинета требуется JavaScript. Пожалуйста, включите его в настройках браузера.
     </p>
   </noscript>


### PR DESCRIPTION
## Summary
- support light and dark themes across cabinet UI
- add night-friendly colors for profile, subscription, devices and security panels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c06906c5f083278b65654164b85951