### PR TITLE
Add support for user name field

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -49,11 +49,11 @@ async function request(
 
 /* ======================== AUTH (WEB) ======================== */
 // REGISTER
-export function authRegister(username, email, password, gender, birth_date, diabetes_type) {
+export function authRegister(username, email, name, password, gender, birth_date, diabetes_type) {
   return request('/auth/web/register', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({ username, email, password, gender, birth_date, diabetes_type })
+    body: JSON.stringify({ username, email, name, password, gender, birth_date, diabetes_type })
   });
 }
 export function authRegisterVerify(challenge_id, code) {

--- a/assets/js/cabinet/app.js
+++ b/assets/js/cabinet/app.js
@@ -245,7 +245,7 @@ export default function AccountApp() {
   };
 
   return React.createElement("div", { className: "min-h-screen w-full bg-slate-50 flex flex-col dark:bg-slate-950 dark:text-slate-100" },
-    React.createElement(SiteHeader, { isAuthed, onLogout: handleLogout, userName: profile?.username || profile?.email }),
+    React.createElement(SiteHeader, { isAuthed, onLogout: handleLogout, userName: profile?.name || profile?.username || profile?.email }),
 
     React.createElement(TransferPremiumModal, {
       open: !!transferContext,

--- a/assets/js/cabinet/panels.js
+++ b/assets/js/cabinet/panels.js
@@ -12,7 +12,7 @@ export function ProfilePanel({ profile, hiddenStatus = true }) {
       React.createElement(SectionCard, null, React.createElement("div", { className: "text-sm text-slate-600" }, "Загружаем профиль…"))
     );
   }
-  const initial = (profile.username || profile.email || "U").trim()[0].toUpperCase();
+  const initial = (profile.name || profile.username || profile.email || "U").trim()[0].toUpperCase();
   const roles = Array.isArray(profile.roles) ? profile.roles : [];
   return React.createElement("div", { className: "space-y-4 w-full" },
     React.createElement(SectionCard, null,
@@ -31,6 +31,7 @@ export function ProfilePanel({ profile, hiddenStatus = true }) {
             React.createElement("div", { className: "text-sm text-slate-500 dark:text-slate-400" }, "Статус"),
             React.createElement("span", { className: profile.is_active ? "text-emerald-700" : "text-rose-600" }, profile.is_active ? "Активен" : "Неактивен")
           ),
+          React.createElement(KeyRow, { label: "Имя", value: profile.name || "—" }),
           React.createElement("div", { className: "flex items-center justify-between py-1.5" },
             React.createElement("div", { className: "text-sm text-slate-500 dark:text-slate-400" }, "Роли"),
             React.createElement("div", { className: "flex flex-wrap gap-1 justify-end" }, roles.map((r) => React.createElement(Chip, { key: r }, r)))


### PR DESCRIPTION
## Summary
- include `name` in registration request
- show user's name in profile panel and use it in header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e350de3c8327a7339cd69ddec14a