### PR TITLE
Fix profile update missing cookies

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -177,7 +177,8 @@ export function authUpdate(fields) {
     method: 'POST',
     headers,
     body: JSON.stringify(fields),
-    credentials: 'omit'
+    // включаем отправку cookies для CSRF-проверки
+    credentials: 'include'
   });
 }
 export function authUpdateVerify(challenge_id, code) {
@@ -188,7 +189,8 @@ export function authUpdateVerify(challenge_id, code) {
     method: 'POST',
     headers,
     body: JSON.stringify({ challenge_id, code }),
-    credentials: 'omit'
+    // требуется cookie csrf_token
+    credentials: 'include'
   });
 }
 
@@ -199,7 +201,8 @@ export function authUpdateResend() {
   return request('/auth/web/update/resend', {
     method: 'POST',
     headers,
-    credentials: 'omit'
+    // сервер ожидает cookie с токеном
+    credentials: 'include'
   });
 }
 


### PR DESCRIPTION
## Summary
- ensure CSRF cookies are sent when updating profile details

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68c801a371c0832793d28c558c88f304