### PR TITLE
Handle email update verification with single new-address code

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -194,13 +194,14 @@ export function authUpdateVerify(challenge_id, code) {
   });
 }
 
-export function authUpdateResend() {
+export function authUpdateResend(challenge_id) {
   const csrf = getCsrfToken();
-  const headers = {};
+  const headers = { 'Content-Type': 'application/json' };
   if (csrf) headers['X-CSRF-Token'] = csrf;
   return request('/auth/web/update/resend', {
     method: 'POST',
     headers,
+    body: JSON.stringify({ challenge_id }),
     // сервер ожидает cookie с токеном
     credentials: 'include'
   });


### PR DESCRIPTION
## Summary
- Send only `challenge_id` and 4-digit `code` when verifying an e-mail update
- Collect a single 4-digit code from the new address in the verification modal
- Invoke verification API with the new code-only approach

## Testing
- `node --experimental-vm-modules -e "const fs=require('fs');const vm=require('vm');new vm.SourceTextModule(fs.readFileSync('assets/js/api.js','utf8'));new vm.SourceTextModule(fs.readFileSync('assets/js/cabinet/panels.js','utf8'));console.log('syntax ok');"`


------
https://chatgpt.com/codex/tasks/task_e_68c80799d6e48327af50f4f692d70af4