### PR TITLE
Fix responsive navigation toggle and profile roles alignment

### DIFF
--- a/assets/js/cabinet/app.js
+++ b/assets/js/cabinet/app.js
@@ -268,7 +268,7 @@ const handleDeleteAccount = async (username, password) => {
     React.createElement("main", { className: "flex-1 mx-auto max-w-screen-2xl px-5 py-6 flex gap-6" },
       React.createElement(Sidebar, { current: section, onChange: setSection }),
       React.createElement("div", { className: "flex-1 min-w-0" },
-        React.createElement("div", { className: "cab-mobile-nav mb-4 grid grid-cols-2 sm:grid-cols-4 gap-2" },
+        React.createElement("div", { className: "cab-mobile-nav mb-4 grid grid-cols-2 sm:grid-cols-4 gap-2 xl:hidden" },
           [
             { key: "profile", label: "Профиль" },
             { key: "subscription", label: "Подписка" },

--- a/assets/js/cabinet/layout.js
+++ b/assets/js/cabinet/layout.js
@@ -54,7 +54,7 @@ export function Sidebar({ current, onChange }) {
           : "hover:bg-slate-50 text-slate-700 dark:hover:bg-slate-700 dark:text-slate-300"
       }`
     }, React.createElement("span", { className: "text-base" }, icon), React.createElement("span", { className: "font-medium" }, label));
-    return React.createElement("aside", { className: "cab-sidebar w-64 shrink-0" },
+    return React.createElement("aside", { className: "cab-sidebar hidden xl:block w-64 shrink-0" },
       React.createElement("div", { className: "sticky top-16 space-y-1" },
         React.createElement(Item, { k: "profile", label: "Профиль", icon: "👤" }),
         React.createElement(Item, { k: "subscription", label: "Подписка", icon: "💎" }),

--- a/assets/js/cabinet/panels.js
+++ b/assets/js/cabinet/panels.js
@@ -32,9 +32,11 @@ export function ProfilePanel({ profile, hiddenStatus = true }) {
             React.createElement("span", { className: profile.is_active ? "text-emerald-700" : "text-rose-600" }, profile.is_active ? "Активен" : "Неактивен")
           ),
           React.createElement(KeyRow, { label: "Имя", value: profile.name || "—" }),
-          React.createElement("div", { className: "flex items-center justify-between py-1.5" },
+          React.createElement("div", { className: "grid grid-cols-[minmax(140px,220px)_1fr] gap-3 items-start py-2" },
             React.createElement("div", { className: "text-sm text-slate-500 dark:text-slate-400" }, "Роли"),
-            React.createElement("div", { className: "flex flex-wrap gap-1 justify-end" }, roles.map((r) => React.createElement(Chip, { key: r }, r)))
+            React.createElement("div", {
+              className: "flex flex-wrap justify-end gap-1 text-sm font-medium text-slate-800 dark:text-slate-100"
+            }, roles.length ? roles.map((r) => React.createElement(Chip, { key: r }, r)) : "—")
           ),
         React.createElement(KeyRow, { label: "Пол", value: mapGender(profile.gender) }),
         React.createElement(KeyRow, { label: "Дата рождения", value: profile.birth_date ? `${fmtDate(profile.birth_date)}${ageFrom(profile.birth_date) ? ` • ${ageFrom(profile.birth_date)} лет` : ""}` : "—" }),


### PR DESCRIPTION
## Summary
- show the sidebar navigation only on desktop widths
- hide the mobile section tabs on wide screens
- align the roles row in the profile card with the rest of the fields

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c90914331883279469341a1a39c556