### PR TITLE
Add personal data processing consent page

### DIFF
--- a/consent.html
+++ b/consent.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Согласие на обработку персональных данных — GluOne</title>
+
+    <meta name="description" content="Согласие на обработку персональных данных для пользователей сервиса GluOne." />
+    <meta name="theme-color" content="#0f172a" />
+    <meta name="color-scheme" content="light dark" />
+
+    <link rel="shortcut icon" href="/favicon.ico?v=4" type="image/x-icon" />
+    <link rel="icon" href="/favicon-32.png?v=4" sizes="32x32" type="image/png" />
+    <link rel="icon" href="/favicon-192.png?v=4" sizes="192x192" type="image/png" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=4" sizes="180x180" />
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+
+    <style>
+      .consent-blank {
+        display: inline-block;
+        min-width: 280px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.65);
+        padding: 0.25rem 0.5rem;
+        vertical-align: middle;
+      }
+      @media (max-width: 640px) {
+        .consent-blank {
+          min-width: 200px;
+        }
+      }
+    </style>
+
+    <script type="module" src="assets/js/core.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+        <a class="flex items-center gap-3" href="/">
+          <img src="assets/image/logo.png" class="h-9 w-9 rounded-xl" alt="Логотип GluOne" width="36" height="36" />
+          <span class="font-semibold tracking-tight">GluOne</span>
+        </a>
+        <a href="/auth.html" class="btn-hero" data-auth-link role="button">Авторизация</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero-bg">
+        <div class="relative max-w-4xl mx-auto px-4 py-12 md:py-16 text-slate-900 dark:text-white">
+          <h1 class="mt-4 text-2xl md:text-3xl font-extrabold leading-tight tracking-tight">
+            Согласие на обработку персональных данных
+          </h1>
+          <p class="mt-5 text-lg text-slate-700 dark:text-slate-300">
+            Настоящее согласие определяет порядок обработки персональных данных пользователей мобильного приложения и веб-сервиса «GluOne».
+          </p>
+        </div>
+      </section>
+
+      <article class="max-w-4xl mx-auto px-4 pb-16 pt-6 text-slate-700 dark:text-slate-300 text-lg leading-relaxed space-y-12">
+        <section class="space-y-4">
+          <p>
+            Я, <span class="consent-blank" aria-hidden="true"></span> (Ф.И.О. пользователя, далее — «Субъект персональных данных»), настоящим свободно, своей волей и в своём интересе даю согласие индивидуальному предпринимателю Киселеву Алексею Борисовичу (ИНН 230110074610, ОГРНИП 324619600076322, адрес: Ростовская обл., г.о. город Батайск, г. Батайск, ул. Северный Массив, д. 15, e-mail: <a href="mailto:notify@gluone.ru" class="underline">notify@gluone.ru</a>) (далее — «Оператор») на обработку моих персональных данных.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">1. Персональные данные, на обработку которых даётся согласие</h2>
+          <ul class="list-disc pl-5 md:pl-6 space-y-2">
+            <li>имя (или выбранный никнейм);</li>
+            <li>пол;</li>
+            <li>дата рождения;</li>
+            <li>тип диабета;</li>
+            <li>адрес электронной почты (e-mail).</li>
+          </ul>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">2. Цели обработки персональных данных</h2>
+          <ul class="list-disc pl-5 md:pl-6 space-y-2">
+            <li>регистрация и идентификация Пользователя в Сервисе «GluOne»;</li>
+            <li>предоставление доступа к функционалу мобильного приложения и веб-сервиса;</li>
+            <li>персонализация интерфейса и расчётов;</li>
+            <li>направление уведомлений и предоставление технической поддержки;</li>
+            <li>выполнение требований законодательства Российской Федерации.</li>
+          </ul>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">3. Действия с персональными данными</h2>
+          <p>
+            Оператор вправе осуществлять следующие действия с персональными данными: сбор, запись, систематизация, накопление, хранение, уточнение (обновление, изменение), извлечение, использование, блокирование, удаление и уничтожение.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">4. Условия обработки</h2>
+          <ul class="list-disc pl-5 md:pl-6 space-y-2">
+            <li>Персональные данные обрабатываются с использованием средств автоматизации и без них.</li>
+            <li>Данные хранятся на серверах, расположенных на территории Российской Федерации, в соответствии с требованиями ФЗ-152.</li>
+            <li>Передача персональных данных третьим лицам допускается только по запросу уполномоченных органов или в случаях, предусмотренных законодательством РФ.</li>
+          </ul>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">5. Срок действия согласия</h2>
+          <p>
+            Согласие действует с момента предоставления данных до момента отзыва согласия Пользователем. Пользователь вправе в любой момент отозвать согласие, направив письменный запрос на адрес электронной почты: <a href="mailto:notify@gluone.ru" class="underline">notify@gluone.ru</a>.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">6. Права субъекта персональных данных</h2>
+          <p>Субъект персональных данных имеет право:</p>
+          <ul class="list-disc pl-5 md:pl-6 space-y-2">
+            <li>получать информацию об обработке своих персональных данных;</li>
+            <li>требовать уточнения, блокирования или уничтожения данных;</li>
+            <li>отозвать согласие на обработку данных;</li>
+            <li>обжаловать действия Оператора в Роскомнадзоре или суде.</li>
+          </ul>
+        </section>
+
+        <section class="space-y-4">
+          <p>
+            Подтверждаю, что ознакомлен(а) с Политикой конфиденциальности, размещённой на сайте <a href="https://gluone.ru/privacy" class="underline">https://gluone.ru/privacy</a>, и соглашаюсь с условиями обработки моих персональных данных.
+          </p>
+          <div class="space-y-3">
+            <p>Дата: «<span class="consent-blank" aria-hidden="true"></span>» <span class="consent-blank" aria-hidden="true"></span> 20<span class="consent-blank" aria-hidden="true"></span> г.</p>
+            <p>Подпись: <span class="consent-blank" aria-hidden="true"></span></p>
+          </div>
+        </section>
+      </article>
+    </main>
+
+    <footer class="max-w-6xl mx-auto px-4 py-10 text-sm text-slate-500 dark:text-slate-400 border-t border-slate-200 dark:border-slate-700">
+      © <span id="y"></span> GluOne · <a href="/privacy.html" class="underline">Политика конфиденциальности</a>
+    </footer>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const yearSpan = document.getElementById('y');
+        if (yearSpan) yearSpan.textContent = new Date().getFullYear();
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone "Согласие на обработку персональных данных" page styled in line with the privacy policy layout
- structure the document into numbered sections covering data categories, processing purposes, operator actions, conditions, duration, and user rights, along with signature placeholders

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68c918fe678c8327b10fdbf647e927be