### PR TITLE
Fix cabinet navigation breakpoints

### DIFF
--- a/assets/js/cabinet/app.js
+++ b/assets/js/cabinet/app.js
@@ -268,7 +268,7 @@ const handleDeleteAccount = async (username, password) => {
     React.createElement("main", { className: "flex-1 mx-auto max-w-screen-2xl px-5 py-6 flex gap-6" },
       React.createElement(Sidebar, { current: section, onChange: setSection }),
       React.createElement("div", { className: "flex-1 min-w-0" },
-        React.createElement("div", { className: "cab-mobile-nav mb-4 grid grid-cols-2 sm:grid-cols-4 gap-2 xl:hidden" },
+        React.createElement("div", { className: "cab-mobile-nav mb-4 grid grid-cols-2 sm:grid-cols-4 gap-2 lg:hidden" },
           [
             { key: "profile", label: "Профиль" },
             { key: "subscription", label: "Подписка" },

--- a/assets/js/cabinet/layout.js
+++ b/assets/js/cabinet/layout.js
@@ -130,7 +130,7 @@ export function Sidebar({ current, onChange }) {
 
   return React.createElement(
     "aside",
-    { className: "cab-sidebar hidden w-64 shrink-0 xl:block" },
+    { className: "cab-sidebar hidden w-64 shrink-0 lg:block" },
     React.createElement(
       "div",
       { className: "sticky top-16 space-y-1" },


### PR DESCRIPTION
## Summary
- align the cabinet mobile navigation breakpoint so it only shows on small and medium screens
- enable the sidebar navigation from large screens to keep desktop navigation visible

## Testing
- no automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c919bdeb9c8327bda6b4e3359a75a2