### PR TITLE
Add public offer page

### DIFF
--- a/offer.html
+++ b/offer.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Публичная оферта — GluOne</title>
+
+    <meta name="description" content="Публичная оферта на заключение договора возмездного оказания услуг сервиса GluOne." />
+    <meta name="theme-color" content="#0f172a" />
+    <meta name="color-scheme" content="light dark" />
+
+    <link rel="shortcut icon" href="/favicon.ico?v=4" type="image/x-icon" />
+    <link rel="icon" href="/favicon-32.png?v=4" sizes="32x32" type="image/png" />
+    <link rel="icon" href="/favicon-192.png?v=4" sizes="192x192" type="image/png" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=4" sizes="180x180" />
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+
+    <script type="module" src="assets/js/core.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+        <a class="flex items-center gap-3" href="/">
+          <img src="assets/image/logo.png" class="h-9 w-9 rounded-xl" alt="Логотип GluOne" width="36" height="36" />
+          <span class="font-semibold tracking-tight">GluOne</span>
+        </a>
+        <a href="/auth.html" class="btn-hero" data-auth-link role="button">Авторизация</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero-bg">
+        <div class="relative max-w-4xl mx-auto px-4 py-12 md:py-16 text-slate-900 dark:text-white">
+          <h1 class="mt-4 text-2xl md:text-3xl font-extrabold leading-tight tracking-tight">Публичная оферта</h1>
+          <p class="mt-5 text-lg text-slate-700 dark:text-slate-300">
+            О заключении договора возмездного оказания услуг сервиса «GluOne».
+          </p>
+        </div>
+      </section>
+
+      <article class="max-w-4xl mx-auto px-4 pb-16 pt-6 text-slate-700 dark:text-slate-300 text-lg leading-relaxed space-y-12">
+        <section class="space-y-4">
+          <p>
+            Индивидуальный предприниматель Киселев Алексей Борисович (ИНН 230110074610, ОГРНИП 324619600076322, адрес: Ростовская
+            обл., г.о. город Батайск, г. Батайск, ул. Северный Массив, д. 15, e-mail:
+            <a href="mailto:notify@gluone.ru" class="underline">notify@gluone.ru</a>), именуемый в дальнейшем «Исполнитель»,
+            публикует настоящую Публичную оферту (далее — «Оферта»), адресованную любому дееспособному физическому лицу (далее —
+            «Заказчик»).
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">1. Общие положения</h2>
+          <ol class="list-decimal pl-5 md:pl-6 space-y-2">
+            <li>Настоящая Оферта является официальным предложением Исполнителя заключить договор возмездного оказания услуг в порядке ст. 437 Гражданского кодекса РФ.</li>
+            <li>Полным и безоговорочным акцептом настоящей Оферты считается факт оплаты Заказчиком услуг Исполнителя.</li>
+            <li>С момента акцепта Оферта считается заключённым договором между Исполнителем и Заказчиком.</li>
+          </ol>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">2. Предмет договора</h2>
+          <ol class="list-decimal pl-5 md:pl-6 space-y-2">
+            <li>Исполнитель обязуется предоставить Заказчику доступ к функционалу мобильного приложения и веб-сервиса «GluOne», включая расширенные возможности, доступные по подписке, а Заказчик обязуется оплатить услуги на условиях настоящей Оферты.</li>
+            <li>Сервис предназначен для ведения персональных записей, связанных с управлением диабетом (учёт показателей, аналитика, рекомендации).</li>
+            <li>Сервис не является медицинской услугой и не заменяет консультацию врача.</li>
+          </ol>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">3. Права и обязанности сторон</h2>
+          <div class="space-y-4">
+            <p>Исполнитель обязуется:</p>
+            <ul class="list-disc pl-5 md:pl-6 space-y-2">
+              <li>предоставлять Заказчику доступ к Сервису в объёме выбранного тарифа;</li>
+              <li>обеспечивать функционирование Сервиса за исключением времени профилактических работ и технических сбоев;</li>
+              <li>консультировать Заказчика по вопросам использования Сервиса через электронную почту.</li>
+            </ul>
+          </div>
+          <div class="space-y-4">
+            <p>Заказчик обязуется:</p>
+            <ul class="list-disc pl-5 md:pl-6 space-y-2">
+              <li>предоставить достоверные данные при регистрации;</li>
+              <li>соблюдать условия настоящей Оферты и Пользовательского соглашения;</li>
+              <li>своевременно оплачивать услуги Исполнителя.</li>
+            </ul>
+          </div>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">4. Стоимость услуг и порядок оплаты</h2>
+          <ol class="list-decimal pl-5 md:pl-6 space-y-2">
+            <li>Актуальная стоимость подписок указывается на сайте <a href="https://gluone.ru" class="underline">https://gluone.ru</a> и/или в мобильном приложении.</li>
+            <li>Оплата осуществляется через платёжных операторов и агрегаторов, обеспечивающих приём банковских карт и иных способов оплаты в соответствии с законодательством Российской Федерации.</li>
+            <li>Оплата считается произведённой с момента подтверждения успешной транзакции платёжным оператором.</li>
+            <li>Исполнитель не хранит реквизиты банковских карт и платёжных средств Заказчиков.</li>
+          </ol>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">5. Возврат средств</h2>
+          <ol class="list-decimal pl-5 md:pl-6 space-y-2">
+            <li>Возврат оплаченной подписки возможен только в случаях, предусмотренных законодательством Российской Федерации.</li>
+            <li>В случае технической ошибки Исполнителя Заказчик вправе направить обращение на e-mail: <a href="mailto:notify@gluone.ru" class="underline">notify@gluone.ru</a>.</li>
+            <li>Вопросы возврата при оплате через сторонние площадки (например, магазины приложений) регулируются правилами соответствующих площадок.</li>
+          </ol>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">6. Ответственность сторон</h2>
+          <ol class="list-decimal pl-5 md:pl-6 space-y-2">
+            <li>Стороны несут ответственность в соответствии с законодательством Российской Федерации.</li>
+            <li>Исполнитель не несёт ответственности за невозможность использования Сервиса по причинам, не зависящим от него (отсутствие доступа в интернет, сбои работы провайдера, устройства Заказчика и др.).</li>
+            <li>Сервис предоставляется «как есть». Исполнитель не гарантирует, что использование Сервиса приведёт к улучшению состояния здоровья Заказчика.</li>
+          </ol>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">7. Срок действия и расторжение договора</h2>
+          <ol class="list-decimal pl-5 md:pl-6 space-y-2">
+            <li>Договор считается заключённым с момента акцепта Оферты и действует до полного исполнения обязательств сторонами.</li>
+            <li>Заказчик вправе в любой момент отказаться от услуг, при этом ранее уплаченные средства не возвращаются, за исключением случаев, предусмотренных разделом 5.</li>
+            <li>Исполнитель вправе в одностороннем порядке расторгнуть договор в случае нарушения Заказчиком условий настоящей Оферты или Пользовательского соглашения.</li>
+          </ol>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">8. Заключительные положения</h2>
+          <ol class="list-decimal pl-5 md:pl-6 space-y-2">
+            <li>Исполнитель вправе вносить изменения в настоящую Оферту. Актуальная редакция всегда доступна на сайте: <a href="https://gluone.ru/offer" class="underline">https://gluone.ru/offer</a>.</li>
+            <li>Ко всем отношениям, не урегулированным настоящей Офертой, применяются нормы действующего законодательства Российской Федерации.</li>
+            <li>В случае возникновения спора стороны будут стремиться урегулировать его путём переговоров. При недостижении согласия спор подлежит рассмотрению в суде по месту нахождения Исполнителя.</li>
+          </ol>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">9. Реквизиты Исполнителя</h2>
+          <ul class="list-disc pl-5 md:pl-6 space-y-2">
+            <li>Индивидуальный предприниматель Киселев Алексей Борисович</li>
+            <li>ИНН: 230110074610</li>
+            <li>ОГРНИП: 324619600076322</li>
+            <li>Адрес: Ростовская обл., г.о. город Батайск, г. Батайск, ул. Северный Массив, д. 15</li>
+            <li>E-mail: <a href="mailto:notify@gluone.ru" class="underline">notify@gluone.ru</a></li>
+          </ul>
+        </section>
+      </article>
+    </main>
+
+    <footer class="max-w-6xl mx-auto px-4 py-10 text-sm text-slate-500 dark:text-slate-400 border-t border-slate-200 dark:border-slate-700">
+      © <span id="y"></span> GluOne · <a href="/privacy.html" class="underline">Политика конфиденциальности</a>
+    </footer>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const yearSpan = document.getElementById('y');
+        if (yearSpan) yearSpan.textContent = new Date().getFullYear();
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a new public offer page that matches the existing legal page styling
- include the full GluOne service offer text and contact details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c91d7b5b008327af2f8ca3284e2491