### PR TITLE
Add legal consent notice to subscription purchase panel

### DIFF
--- a/assets/js/cabinet/panels.js
+++ b/assets/js/cabinet/panels.js
@@ -93,6 +93,23 @@ export function SubscriptionPanel({ onOpenTransfer, currentDeviceName, onPay, pl
             );
           })(),
           React.createElement("button", { onClick: onOpenTransfer, className: "rounded-xl border border-slate-200 px-5 py-3 font-semibold text-base bg-white hover:bg-slate-50 dark:bg-slate-800 dark:border-slate-600 dark:hover:bg-slate-700" }, "Сменить устройство")
+        ),
+        React.createElement("p", { className: "mt-3 text-[13px] text-slate-500 dark:text-slate-400" },
+          "Нажимая кнопку «Купить», вы подтверждаете согласие с ",
+          React.createElement("a", {
+            href: "https://gluone.ru/offer.html",
+            className: "text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300",
+            target: "_blank",
+            rel: "noopener noreferrer"
+          }, "Публичной офертой"),
+          " и ",
+          React.createElement("a", {
+            href: "https://gluone.ru/privacy.html",
+            className: "text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300",
+            target: "_blank",
+            rel: "noopener noreferrer"
+          }, "Политикой конфиденциальности"),
+          "."
         )
       )
     );


### PR DESCRIPTION
## Summary
- add a consent notice below the subscription purchase actions in the cabinet
- link to the public offer and privacy policy with blue styling for dark and light modes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c91f2667748327b4c3056a5b924472