### PR TITLE
Fix cabinet navigation visibility

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -435,6 +435,32 @@ button, .btn-hero, .btn-outline, .btn-primary{
   -webkit-tap-highlight-color: transparent;
 }
 
+/* ===== Cabinet responsive navigation ===== */
+.cab-header-nav{ display:none; }
+@media (min-width: 768px){
+  .cab-header-nav{ display:flex; }
+}
+
+.cab-sidebar{ display:none; }
+@media (min-width: 1024px){
+  .cab-sidebar{ display:block; }
+}
+
+.cab-mobile-nav{
+  display:grid;
+  gap:0.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-bottom: 1rem;
+}
+@media (min-width: 640px){
+  .cab-mobile-nav{
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+@media (min-width: 1024px){
+  .cab-mobile-nav{ display:none; }
+}
+
 /* 8) Forced colors / High-contrast */
 @media (forced-colors: active){
   .btn-hero, .btn-outline, .btn-primary, .field, .card, .feature-card{

--- a/assets/js/cabinet/app.js
+++ b/assets/js/cabinet/app.js
@@ -268,7 +268,7 @@ const handleDeleteAccount = async (username, password) => {
     React.createElement("main", { className: "flex-1 mx-auto max-w-screen-2xl px-5 py-6 flex gap-6" },
       React.createElement(Sidebar, { current: section, onChange: setSection }),
       React.createElement("div", { className: "flex-1 min-w-0" },
-        React.createElement("div", { className: "cab-mobile-nav mb-4 grid grid-cols-2 sm:grid-cols-4 gap-2 xl:hidden" },
+        React.createElement("div", { className: "cab-mobile-nav" },
           [
             { key: "profile", label: "Профиль" },
             { key: "subscription", label: "Подписка" },

--- a/assets/js/cabinet/layout.js
+++ b/assets/js/cabinet/layout.js
@@ -91,7 +91,7 @@ export function SiteHeader({ isAuthed, onLogout, userName }) {
       ),
       React.createElement(
         "nav",
-        { className: "hidden md:flex items-center gap-6 text-sm text-slate-600 dark:text-slate-400" },
+        { className: "cab-header-nav items-center gap-6 text-sm text-slate-600 dark:text-slate-400" },
         React.createElement(
           "a",
           { className: "hover:text-slate-900 dark:hover:text-slate-100", href: "https://gluone.ru" },
@@ -130,7 +130,7 @@ export function Sidebar({ current, onChange }) {
 
   return React.createElement(
     "aside",
-    { className: "cab-sidebar hidden w-64 shrink-0 xl:block" },
+    { className: "cab-sidebar w-64 shrink-0" },
     React.createElement(
       "div",
       { className: "sticky top-16 space-y-1" },


### PR DESCRIPTION
## Summary
- add cabinet-specific responsive styles so desktop and mobile navigation never disappear
- update the cabinet header, sidebar and tab strip to use the new classes instead of Tailwind's hidden utilities

## Testing
- no automated tests (static site)

------
https://chatgpt.com/codex/tasks/task_e_68c919bdeb9c8327bda6b4e3359a75a2