### PR TITLE
Add user agreement page

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,388 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Пользовательское соглашение — GluOne</title>
+
+    <meta
+      name="description"
+      content="Пользовательское соглашение мобильного приложения и веб-сервиса GluOne."
+    />
+    <meta name="theme-color" content="#0f172a" />
+    <meta name="color-scheme" content="light dark" />
+
+    <link rel="shortcut icon" href="/favicon.ico?v=4" type="image/x-icon" />
+    <link rel="icon" href="/favicon-32.png?v=4" sizes="32x32" type="image/png" />
+    <link rel="icon" href="/favicon-192.png?v=4" sizes="192x192" type="image/png" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=4" sizes="180x180" />
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+
+    <style>
+      .legal-card {
+        backdrop-filter: blur(14px);
+        -webkit-backdrop-filter: blur(14px);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+      .legal-card:hover {
+        transform: translateY(-2px);
+        box-shadow: var(--shadow-hover);
+      }
+      .section-anchor {
+        scroll-margin-top: 120px;
+      }
+      @media (max-width: 768px) {
+        .section-anchor {
+          scroll-margin-top: 96px;
+        }
+      }
+    </style>
+
+    <script type="module" src="assets/js/core.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+        <a class="flex items-center gap-3" href="/">
+          <img
+            src="assets/image/logo.png"
+            class="h-9 w-9 rounded-xl"
+            alt="Логотип GluOne"
+            width="36"
+            height="36"
+          />
+          <span class="font-semibold tracking-tight">GluOne</span>
+        </a>
+        <a href="/auth.html" class="btn-hero" data-auth-link role="button">Авторизация</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero-bg">
+        <div class="relative max-w-4xl mx-auto px-4 py-12 md:py-16 text-slate-900 dark:text-white">
+          <h1 class="mt-4 text-2xl md:text-3xl font-extrabold leading-tight tracking-tight">
+            Пользовательское соглашение мобильного приложения и&nbsp;веб-сервиса «GluOne»
+          </h1>
+          <p class="mt-5 text-lg text-slate-700 dark:text-slate-300">
+            Документ определяет условия использования сервиса GluOne, порядок доступа к функционалу и ответственность сторон.
+          </p>
+          <p class="mt-7 text-sm text-slate-600 dark:text-slate-400">
+            Дата вступления в силу: <time datetime="2025-10-10">10.10.2025</time>
+          </p>
+        </div>
+      </section>
+
+      <nav aria-label="Разделы соглашения" class="max-w-4xl mx-auto px-4 mt-10">
+        <div class="grid gap-3 sm:grid-cols-2">
+          <a
+            href="#section-1"
+            class="legal-card group flex items-center gap-4 rounded-2xl border border-slate-200/80 dark:border-slate-700/80 bg-white/70 dark:bg-slate-900/60 p-4 no-underline"
+          >
+            <span
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-100 font-semibold text-slate-600 transition group-hover:bg-slate-900 group-hover:text-white dark:bg-slate-800 dark:text-slate-200 dark:group-hover:bg-white dark:group-hover:text-slate-900"
+              >1</span
+            >
+            <div>
+              <p class="font-semibold text-slate-900 dark:text-white">Общие положения</p>
+              <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">Правовой статус документа и принятие условий.</p>
+            </div>
+          </a>
+          <a
+            href="#section-2"
+            class="legal-card group flex items-center gap-4 rounded-2xl border border-slate-200/80 dark:border-slate-700/80 bg-white/70 dark:bg-slate-900/60 p-4 no-underline"
+          >
+            <span
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-100 font-semibold text-slate-600 transition group-hover:bg-slate-900 group-hover:text-white dark:bg-slate-800 dark:text-slate-200 dark:group-hover:bg-white dark:group-hover:text-slate-900"
+              >2</span
+            >
+            <div>
+              <p class="font-semibold text-slate-900 dark:text-white">Предмет соглашения</p>
+              <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">Что предоставляет сервис GluOne.</p>
+            </div>
+          </a>
+          <a
+            href="#section-3"
+            class="legal-card group flex items-center gap-4 rounded-2xl border border-slate-200/80 dark:border-slate-700/80 bg-white/70 dark:bg-slate-900/60 p-4 no-underline"
+          >
+            <span
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-100 font-semibold text-slate-600 transition group-hover:bg-slate-900 group-hover:text-white dark:bg-slate-800 dark:text-slate-200 dark:group-hover:bg-white dark:group-hover:text-slate-900"
+              >3</span
+            >
+            <div>
+              <p class="font-semibold text-slate-900 dark:text-white">Регистрация и аккаунт</p>
+              <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">Правила создания и использования учётной записи.</p>
+            </div>
+          </a>
+          <a
+            href="#section-4"
+            class="legal-card group flex items-center gap-4 rounded-2xl border border-slate-200/80 dark:border-slate-700/80 bg-white/70 dark:bg-slate-900/60 p-4 no-underline"
+          >
+            <span
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-100 font-semibold text-slate-600 transition group-hover:bg-slate-900 group-hover:text-white dark:bg-slate-800 dark:text-slate-200 dark:group-hover:bg-white dark:group-hover:text-slate-900"
+              >4</span
+            >
+            <div>
+              <p class="font-semibold text-slate-900 dark:text-white">Права и обязанности</p>
+              <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">Обязанности и возможности сторон соглашения.</p>
+            </div>
+          </a>
+          <a
+            href="#section-5"
+            class="legal-card group flex items-center gap-4 rounded-2xl border border-slate-200/80 dark:border-slate-700/80 bg-white/70 dark:bg-slate-900/60 p-4 no-underline"
+          >
+            <span
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-100 font-semibold text-slate-600 transition group-hover:bg-slate-900 group-hover:text-white dark:bg-slate-800 dark:text-slate-200 dark:group-hover:bg-white dark:group-hover:text-slate-900"
+              >5</span
+            >
+            <div>
+              <p class="font-semibold text-slate-900 dark:text-white">Ограничение ответственности</p>
+              <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">Дисклеймеры и ограничения сервиса.</p>
+            </div>
+          </a>
+          <a
+            href="#section-6"
+            class="legal-card group flex items-center gap-4 rounded-2xl border border-slate-200/80 dark:border-slate-700/80 bg-white/70 dark:bg-slate-900/60 p-4 no-underline"
+          >
+            <span
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-100 font-semibold text-slate-600 transition group-hover:bg-slate-900 group-hover:text-white dark:bg-slate-800 dark:text-slate-200 dark:group-hover:bg-white dark:group-hover:text-slate-900"
+              >6</span
+            >
+            <div>
+              <p class="font-semibold text-slate-900 dark:text-white">Интеллектуальная собственность</p>
+              <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">Условия использования материалов GluOne.</p>
+            </div>
+          </a>
+          <a
+            href="#section-7"
+            class="legal-card group flex items-center gap-4 rounded-2xl border border-slate-200/80 dark:border-slate-700/80 bg-white/70 dark:bg-slate-900/60 p-4 no-underline"
+          >
+            <span
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-100 font-semibold text-slate-600 transition group-hover:bg-slate-900 group-hover:text-white dark:bg-slate-800 dark:text-slate-200 dark:group-hover:bg-white dark:group-hover:text-slate-900"
+              >7</span
+            >
+            <div>
+              <p class="font-semibold text-slate-900 dark:text-white">Изменения условий</p>
+              <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">Как обновляется пользовательское соглашение.</p>
+            </div>
+          </a>
+          <a
+            href="#section-8"
+            class="legal-card group flex items-center gap-4 rounded-2xl border border-slate-200/80 dark:border-slate-700/80 bg-white/70 dark:bg-slate-900/60 p-4 no-underline"
+          >
+            <span
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-100 font-semibold text-slate-600 transition group-hover:bg-slate-900 group-hover:text-white dark:bg-slate-800 dark:text-slate-200 dark:group-hover:bg-white dark:group-hover:text-slate-900"
+              >8</span
+            >
+            <div>
+              <p class="font-semibold text-slate-900 dark:text-white">Заключительные положения</p>
+              <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">Применимое право и порядок разрешения споров.</p>
+            </div>
+          </a>
+          <a
+            href="#section-9"
+            class="legal-card group flex items-center gap-4 rounded-2xl border border-slate-200/80 dark:border-slate-700/80 bg-white/70 dark:bg-slate-900/60 p-4 no-underline"
+          >
+            <span
+              class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-100 font-semibold text-slate-600 transition group-hover:bg-slate-900 group-hover:text-white dark:bg-slate-800 dark:text-slate-200 dark:group-hover:bg-white dark:group-hover:text-slate-900"
+              >9</span
+            >
+            <div>
+              <p class="font-semibold text-slate-900 dark:text-white">Контакты</p>
+              <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">Как связаться с оператором сервиса.</p>
+            </div>
+          </a>
+        </div>
+      </nav>
+
+      <article class="max-w-4xl mx-auto px-4 pb-16 pt-6 text-slate-700 dark:text-slate-300 text-lg leading-relaxed space-y-12">
+        <section id="section-1" class="section-anchor space-y-4">
+          <h2 class="flex items-baseline gap-3 text-2xl font-semibold text-slate-900 dark:text-white">
+            <span class="font-bold">1.</span>
+            <span>Общие положения</span>
+          </h2>
+          <div class="space-y-3 pl-5 md:pl-6">
+            <p>
+              <strong>1.1.</strong>
+              Настоящее Соглашение является договором присоединения в смысле статьи 428 Гражданского кодекса Российской Федерации.
+            </p>
+            <p><strong>1.2.</strong> Используя Сервис, Пользователь подтверждает согласие с условиями Соглашения.</p>
+            <p><strong>1.3.</strong> В случае несогласия с условиями документа Пользователь обязан прекратить использование Сервиса.
+            </p>
+          </div>
+        </section>
+
+        <section id="section-2" class="section-anchor space-y-4">
+          <h2 class="flex items-baseline gap-3 text-2xl font-semibold text-slate-900 dark:text-white">
+            <span class="font-bold">2.</span>
+            <span>Предмет соглашения</span>
+          </h2>
+          <div class="space-y-3 pl-5 md:pl-6">
+            <p>
+              <strong>2.1.</strong>
+              Оператор предоставляет Пользователю доступ к функционалу Сервиса «GluOne» для ведения персональных записей, связанн
+ых с управлением диабетом, включая учёт показателей, аналитику и напоминания.
+            </p>
+            <p><strong>2.2.</strong> Сервис предоставляется исключительно в информационных целях и не заменяет консультацию врача.
+            </p>
+            <p>
+              <strong>2.3.</strong>
+              Условия обработки персональных данных определяются
+              <a
+                href="https://gluone.ru/privacy.html"
+                class="underline decoration-dotted"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Политикой конфиденциальности
+              </a>.
+            </p>
+          </div>
+        </section>
+
+        <section id="section-3" class="section-anchor space-y-4">
+          <h2 class="flex items-baseline gap-3 text-2xl font-semibold text-slate-900 dark:text-white">
+            <span class="font-bold">3.</span>
+            <span>Регистрация и аккаунт</span>
+          </h2>
+          <div class="space-y-3 pl-5 md:pl-6">
+            <p><strong>3.1.</strong> Для доступа к функционалу Сервиса Пользователь должен пройти регистрацию, указав достоверные данные.
+            </p>
+            <p><strong>3.2.</strong> Пользователь обязуется не передавать свои учётные данные третьим лицам и обеспечивать их сохранность.
+            </p>
+            <p>
+              <strong>3.3.</strong>
+              Оператор вправе ограничить или прекратить доступ к Сервису в случае нарушения Пользователем условий настоящего Со
+глашения.
+            </p>
+          </div>
+        </section>
+
+        <section id="section-4" class="section-anchor space-y-4">
+          <h2 class="flex items-baseline gap-3 text-2xl font-semibold text-slate-900 dark:text-white">
+            <span class="font-bold">4.</span>
+            <span>Права и обязанности сторон</span>
+          </h2>
+          <div class="space-y-5 pl-5 md:pl-6">
+            <div>
+              <p><strong>4.1.</strong> Пользователь обязуется:</p>
+              <ul class="mt-2 list-disc space-y-2 pl-6 marker:text-slate-400 dark:marker:text-slate-600">
+                <li>использовать Сервис только в законных целях;</li>
+                <li>не предпринимать действий, направленных на нарушение работы Сервиса;</li>
+                <li>не выдавать себя за другое лицо и не предоставлять заведомо ложные данные.</li>
+              </ul>
+            </div>
+            <div>
+              <p><strong>4.2.</strong> Пользователь имеет право:</p>
+              <ul class="mt-2 list-disc space-y-2 pl-6 marker:text-slate-400 dark:marker:text-slate-600">
+                <li>пользоваться функционалом Сервиса в пределах предоставленных возможностей;</li>
+                <li>обращаться в службу поддержки по вопросам использования Сервиса;</li>
+                <li>удалить свою учётную запись.</li>
+              </ul>
+            </div>
+            <div>
+              <p><strong>4.3.</strong> Оператор обязуется:</p>
+              <ul class="mt-2 list-disc space-y-2 pl-6 marker:text-slate-400 dark:marker:text-slate-600">
+                <li>предоставлять доступ к Сервису в соответствии с настоящим Соглашением;</li>
+                <li>обеспечивать стабильную работу Сервиса за исключением времени профилактических и аварийных работ;</li>
+                <li>информировать Пользователя о существенных изменениях в работе Сервиса.</li>
+              </ul>
+            </div>
+            <div>
+              <p><strong>4.4.</strong> Оператор имеет право:</p>
+              <ul class="mt-2 list-disc space-y-2 pl-6 marker:text-slate-400 dark:marker:text-slate-600">
+                <li>изменять функционал Сервиса без предварительного уведомления Пользователя;</li>
+                <li>временно приостанавливать работу Сервиса для проведения технических работ;</li>
+                <li>блокировать или удалять аккаунт Пользователя в случае нарушения Соглашения.</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section id="section-5" class="section-anchor space-y-4">
+          <h2 class="flex items-baseline gap-3 text-2xl font-semibold text-slate-900 dark:text-white">
+            <span class="font-bold">5.</span>
+            <span>Ограничение ответственности</span>
+          </h2>
+          <div class="space-y-3 pl-5 md:pl-6">
+            <p><strong>5.1.</strong> Сервис предоставляется «как есть». Оператор не гарантирует безошибочную и бесперебойную работу Сервиса.
+            </p>
+            <div>
+              <p><strong>5.2.</strong> Оператор не несёт ответственности за:</p>
+              <ul class="mt-2 list-disc space-y-2 pl-6 marker:text-slate-400 dark:marker:text-slate-600">
+                <li>действия Пользователя, приведшие к утечке персональных данных;</li>
+                <li>сбои работы оборудования или интернет-провайдера Пользователя;</li>
+                <li>невозможность использования Сервиса по причинам, не зависящим от Оператора.</li>
+              </ul>
+            </div>
+            <p>
+              <strong>5.3.</strong>
+              Сервис не является медицинской услугой и не предназначен для постановки диагнозов или назначения лечения. Все данн
+ые, отображаемые в Сервисе, носят исключительно справочный характер.
+            </p>
+          </div>
+        </section>
+
+        <section id="section-6" class="section-anchor space-y-4">
+          <h2 class="flex items-baseline gap-3 text-2xl font-semibold text-slate-900 dark:text-white">
+            <span class="font-bold">6.</span>
+            <span>Интеллектуальная собственность</span>
+          </h2>
+          <div class="space-y-3 pl-5 md:pl-6">
+            <p>
+              <strong>6.1.</strong>
+              Все элементы Сервиса, включая дизайн, программный код, базы данных, тексты, графику и логотипы, являются объектами
+ интеллектуальной собственности Оператора и охраняются законодательством Российской Федерации.
+            </p>
+            <p>
+              <strong>6.2.</strong>
+              Пользователь не вправе копировать, распространять, изменять или использовать материалы Сервиса без письменного сог
+ласия Оператора.
+            </p>
+          </div>
+        </section>
+
+        <section id="section-7" class="section-anchor space-y-4">
+          <h2 class="flex items-baseline gap-3 text-2xl font-semibold text-slate-900 dark:text-white">
+            <span class="font-bold">7.</span>
+            <span>Изменения условий</span>
+          </h2>
+          <div class="space-y-3 pl-5 md:pl-6">
+            <p><strong>7.1.</strong> Оператор вправе изменять настоящее Соглашение в одностороннем порядке.</p>
+            <p><strong>7.2.</strong> Актуальная версия Соглашения всегда доступна на сайте: <a href="https://gluone.ru/terms" class="underline decoration-dotted">https://gluone.ru/terms</a>.
+            </p>
+          </div>
+        </section>
+
+        <section id="section-8" class="section-anchor space-y-4">
+          <h2 class="flex items-baseline gap-3 text-2xl font-semibold text-slate-900 dark:text-white">
+            <span class="font-bold">8.</span>
+            <span>Заключительные положения</span>
+          </h2>
+          <div class="space-y-3 pl-5 md:pl-6">
+            <p><strong>8.1.</strong> Настоящее Соглашение регулируется законодательством Российской Федерации.</p>
+            <p>
+              <strong>8.2.</strong>
+              Все споры между Оператором и Пользователем разрешаются путём переговоров, а при недостижении согласия — в суде по месту нахождения Оператора.
+            </p>
+          </div>
+        </section>
+
+        <section id="section-9" class="section-anchor space-y-4">
+          <h2 class="flex items-baseline gap-3 text-2xl font-semibold text-slate-900 dark:text-white">
+            <span class="font-bold">9.</span>
+            <span>Контактные данные</span>
+          </h2>
+          <div class="space-y-2 pl-5 md:pl-6 text-base">
+            <p><strong>Индивидуальный предприниматель Киселев Алексей Борисович</strong></p>
+            <p>ИНН: 230110074610</p>
+            <p>ОГРНИП: 324619600076322</p>
+            <p>Адрес: Ростовская обл., г.о. город Батайск, г. Батайск, ул. Северный Массив, д. 15</p>
+            <p>E-mail: <a href="mailto:notify@gluone.ru" class="underline decoration-dotted">notify@gluone.ru</a></p>
+          </div>
+        </section>
+      </article>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `terms.html` page with GluOne user agreement content styled consistently with the privacy policy
- include navigation cards and detailed sections covering rights, responsibilities, liability, and contact details

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c921f0cb808327837882b86c489ba1