### PR TITLE
Update internal links to extensionless routes

### DIFF
--- a/assets/css/cabinet.css
+++ b/assets/css/cabinet.css
@@ -218,7 +218,7 @@
   color:var(--danger-text);
 }
 
-/* ==== Показ/скрытие пароля (как в auth.html) ==== */
+/* ==== Показ/скрытие пароля (как на странице авторизации) ==== */
 .form-field .field-wrap{
   position: relative;
   display: block;

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -214,7 +214,7 @@ import { KEYS, save } from './storage.js';
           ? `Код отправлен на e-mail. Введите его для подтверждения.`
           : 'Код подтверждения отправлен. Проверьте почту.';
         formMsg.style.color = '#059669';
-        window.location.href = 'confirm.html';
+        window.location.href = '/confirm';
         return;
       }
 

--- a/assets/js/cabinet/app.js
+++ b/assets/js/cabinet/app.js
@@ -38,7 +38,7 @@ export default function AccountApp() {
       const r = await authRefresh();
       if (!r.ok) {
         setIsAuthed(false);
-        window.location.href = "/auth.html?next=%2Fcabinet.html";
+        window.location.href = "/auth?next=%2Fcabinet";
         return;
       }
 
@@ -48,7 +48,7 @@ export default function AccountApp() {
         setIsAuthed(true);
       } else {
         setIsAuthed(false);
-        window.location.href = "/auth.html?next=%2Fcabinet.html";
+        window.location.href = "/auth?next=%2Fcabinet";
         return;
       }
 
@@ -143,7 +143,7 @@ export default function AccountApp() {
   const handleLogout = async () => {
     try { await authLogout(); } catch {}
     clearAuthStorage();
-    window.location.href = "/auth.html";
+    window.location.href = "/auth";
   };
 
   const handleChangePassword = async (oldPwd, newPwd) => {
@@ -317,7 +317,7 @@ const handleDeleteAccount = async (username, password) => {
       React.createElement("div", { className: "mx-auto max-w-screen-2xl px-5 py-6 text-sm text-slate-500 dark:text-slate-400 flex flex-wrap items-center justify-between gap-3" },
         React.createElement("div", null, "© ", (new Date()).getFullYear(), " GluOne. Все права защищены."),
         React.createElement("div", { className: "flex items-center gap-4" },
-          React.createElement("a", { className: "hover:text-slate-700 dark:hover:text-slate-200", href: "https://gluone.ru/privacy.html" }, "Политика конфиденциальности"),
+          React.createElement("a", { className: "hover:text-slate-700 dark:hover:text-slate-200", href: "https://gluone.ru/privacy" }, "Политика конфиденциальности"),
           React.createElement("a", { className: "hover:text-slate-700 dark:hover:text-slate-200", href: "#" }, "Условия"),
           React.createElement("a", { className: "hover:text-slate-700 dark:hover:text-slate-200", href: "#" }, "Контакты")
         )

--- a/assets/js/cabinet/layout.js
+++ b/assets/js/cabinet/layout.js
@@ -7,7 +7,7 @@ export function UserMenu({ isAuthed, userName = "", onLogout }) {
 
   const handleClick = () => {
     if (!isAuthed) {
-      window.location.href = "https://gluone.ru/auth.html";
+      window.location.href = "https://gluone.ru/auth";
       return;
     }
     setOpen((v) => !v);

--- a/assets/js/cabinet/panels.js
+++ b/assets/js/cabinet/panels.js
@@ -99,14 +99,14 @@ export function SubscriptionPanel({ onOpenTransfer, currentDeviceName, onPay, pl
           React.createElement("br", null),
           "с ",
           React.createElement("a", {
-            href: "https://gluone.ru/offer.html",
+            href: "https://gluone.ru/offer",
             className: "text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300",
             target: "_blank",
             rel: "noopener noreferrer"
           }, "Публичной офертой"),
           " и ",
           React.createElement("a", {
-            href: "https://gluone.ru/privacy.html",
+            href: "https://gluone.ru/privacy",
             className: "text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300",
             target: "_blank",
             rel: "noopener noreferrer"

--- a/assets/js/confirm.js
+++ b/assets/js/confirm.js
@@ -35,7 +35,7 @@ import { KEYS, load, save, del } from './storage.js';
 
     if (!challengeId) {
       setMsg('Сессия подтверждения не найдена. Возвращаемся на шаг входа…', '#e11d48');
-      setTimeout(() => { window.location.href = '/auth.html'; }, 1200);
+      setTimeout(() => { window.location.href = '/auth'; }, 1200);
       return;
     }
 
@@ -78,7 +78,7 @@ import { KEYS, load, save, del } from './storage.js';
           del(KEYS.CHALLENGE);
 
           setMsg('Готово! Входим…', '#059669');
-          const next = new URLSearchParams(location.search).get('next') || '/cabinet.html';
+          const next = new URLSearchParams(location.search).get('next') || '/cabinet';
           window.location.href = next;
           return;
         }

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -32,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const authLink = document.querySelector('#authEntry, [data-auth-link]');
   if (authLink) {
     authLink.textContent = 'Авторизация';
-    authLink.setAttribute('href', '/auth.html');
+    authLink.setAttribute('href', '/auth');
 
     (async () => {
       try {
@@ -42,7 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (me.ok && me.data) {
           const label = me.data.username || 'Личный кабинет';
           authLink.textContent = label;
-          authLink.setAttribute('href', '/cabinet.html');
+          authLink.setAttribute('href', '/cabinet');
         }
       } catch {}
     })();

--- a/consent.html
+++ b/consent.html
@@ -41,7 +41,7 @@
           <img src="assets/image/logo.png" class="h-9 w-9 rounded-xl" alt="Логотип GluOne" width="36" height="36" />
           <span class="font-semibold tracking-tight">GluOne</span>
         </a>
-        <a href="/auth.html" class="btn-hero" data-auth-link role="button">Авторизация</a>
+        <a href="/auth" class="btn-hero" data-auth-link role="button">Авторизация</a>
       </div>
     </header>
 
@@ -133,7 +133,7 @@
     </main>
 
     <footer class="max-w-6xl mx-auto px-4 py-10 text-sm text-slate-500 dark:text-slate-400 border-t border-slate-200 dark:border-slate-700">
-      © <span id="y"></span> GluOne · <a href="/privacy.html" class="underline">Политика конфиденциальности</a>
+      © <span id="y"></span> GluOne · <a href="/privacy" class="underline">Политика конфиденциальности</a>
     </footer>
 
     <script>

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
         <img src="assets/image/logo.png" class="h-9 w-9 rounded-xl" alt="GluOne logo" width="36" height="36" />
         <span class="font-semibold tracking-tight">GluOne</span>
       </a>
-      <a href="/auth.html" class="btn-hero" data-auth-link role="button">Авторизация</a>
+      <a href="/auth" class="btn-hero" data-auth-link role="button">Авторизация</a>
     </header>
 
     <!-- HERO -->
@@ -98,7 +98,7 @@
               Контролируйте глюкозу, питание, инсулин и активность в одном приложении.
             </p>
             <div class="mt-7 flex items-center gap-4 flex-wrap">
-              <a href="/auth.html" class="btn-hero" data-auth-link role="button">Авторизация</a>
+              <a href="/auth" class="btn-hero" data-auth-link role="button">Авторизация</a>
               <a
                 href="https://apps.apple.com/app/idXXXXXXXX"
                 target="_blank" rel="noopener noreferrer"
@@ -224,7 +224,7 @@
 
     <!-- Footer -->
     <footer class="max-w-6xl mx-auto px-4 py-10 text-sm text-slate-500 dark:text-slate-400 border-t border-slate-200 dark:border-slate-700">
-      © <span id="y"></span> GluOne · <a href="/privacy.html" class="underline">Политика конфиденциальности</a>
+      © <span id="y"></span> GluOne · <a href="/privacy" class="underline">Политика конфиденциальности</a>
     </footer>
 
     <!-- Tabs + год -->

--- a/offer.html
+++ b/offer.html
@@ -26,7 +26,7 @@
           <img src="assets/image/logo.png" class="h-9 w-9 rounded-xl" alt="Логотип GluOne" width="36" height="36" />
           <span class="font-semibold tracking-tight">GluOne</span>
         </a>
-        <a href="/auth.html" class="btn-hero" data-auth-link role="button">Авторизация</a>
+        <a href="/auth" class="btn-hero" data-auth-link role="button">Авторизация</a>
       </div>
     </header>
 
@@ -149,7 +149,7 @@
     </main>
 
     <footer class="max-w-6xl mx-auto px-4 py-10 text-sm text-slate-500 dark:text-slate-400 border-t border-slate-200 dark:border-slate-700">
-      © <span id="y"></span> GluOne · <a href="/privacy.html" class="underline">Политика конфиденциальности</a>
+      © <span id="y"></span> GluOne · <a href="/privacy" class="underline">Политика конфиденциальности</a>
     </footer>
 
     <script>

--- a/privacy.html
+++ b/privacy.html
@@ -44,7 +44,7 @@
           <img src="assets/image/logo.png" class="h-9 w-9 rounded-xl" alt="Логотип GluOne" width="36" height="36" />
           <span class="font-semibold tracking-tight">GluOne</span>
         </a>
-        <a href="/auth.html" class="btn-hero" data-auth-link role="button">Авторизация</a>
+        <a href="/auth" class="btn-hero" data-auth-link role="button">Авторизация</a>
       </div>
     </header>
 
@@ -304,7 +304,7 @@
     </main>
 
     <footer class="max-w-6xl mx-auto px-4 py-10 text-sm text-slate-500 dark:text-slate-400 border-t border-slate-200 dark:border-slate-700">
-      © <span id="y"></span> GluOne · <a href="/privacy.html" class="underline">Политика конфиденциальности</a>
+      © <span id="y"></span> GluOne · <a href="/privacy" class="underline">Политика конфиденциальности</a>
     </footer>
 
     <script>

--- a/terms.html
+++ b/terms.html
@@ -55,7 +55,7 @@
           />
           <span class="font-semibold tracking-tight">GluOne</span>
         </a>
-        <a href="/auth.html" class="btn-hero" data-auth-link role="button">Авторизация</a>
+        <a href="/auth" class="btn-hero" data-auth-link role="button">Авторизация</a>
       </div>
     </header>
 
@@ -230,7 +230,7 @@
               <strong>2.3.</strong>
               Условия обработки персональных данных определяются
               <a
-                href="https://gluone.ru/privacy.html"
+                href="https://gluone.ru/privacy"
                 class="underline decoration-dotted"
                 target="_blank"
                 rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- update internal navigation links to use extensionless URLs across public pages
- adjust application scripts to redirect to the new extensionless routes
- refresh footer references and cabinet assets to match the new routing scheme

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9263bad2c8327b23c45c1ca517a0e