### PR TITLE
Add contacts page and update footer navigation

### DIFF
--- a/assets/js/cabinet/app.js
+++ b/assets/js/cabinet/app.js
@@ -319,7 +319,7 @@ const handleDeleteAccount = async (username, password) => {
         React.createElement("div", { className: "flex items-center gap-4" },
           React.createElement("a", { className: "hover:text-slate-700 dark:hover:text-slate-200", href: "https://gluone.ru/privacy" }, "Политика конфиденциальности"),
           React.createElement("a", { className: "hover:text-slate-700 dark:hover:text-slate-200", href: "https://gluone.ru/terms.html" }, "Пользовательское соглашение"),
-          React.createElement("a", { className: "hover:text-slate-700 dark:hover:text-slate-200", href: "#" }, "Контакты")
+          React.createElement("a", { className: "hover:text-slate-700 dark:hover:text-slate-200", href: "https://gluone.ru/contacts" }, "Контакты")
         )
       )
     )

--- a/consent.html
+++ b/consent.html
@@ -134,8 +134,18 @@
       </article>
     </main>
 
-    <footer class="max-w-6xl mx-auto px-4 py-10 text-sm text-slate-500 dark:text-slate-400 border-t border-slate-200 dark:border-slate-700">
-      © <span id="y"></span> GluOne · <a href="/privacy" class="underline">Политика конфиденциальности</a>
+    <footer class="border-t border-slate-200 dark:border-slate-700">
+      <div
+        class="max-w-6xl mx-auto flex flex-col gap-4 px-4 py-10 text-sm text-slate-500 dark:text-slate-400 md:flex-row md:items-center md:justify-between"
+      >
+        <p>© <span id="y"></span> GluOne</p>
+        <nav class="flex flex-wrap items-center gap-x-5 gap-y-2" aria-label="Нижняя навигация">
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/privacy">Политика конфиденциальности</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/terms.html">Пользовательское соглашение</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/offer">Публичная оферта</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/contacts">Контакты</a>
+        </nav>
+      </div>
     </footer>
 
     <script>

--- a/contacts.html
+++ b/contacts.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Контакты — GluOne</title>
+
+    <meta
+      name="description"
+      content="Контакты GluOne: поддержка пользователей и реквизиты ИП Киселев А.Б.; email notify@gluone.ru, Telegram @GluOneNews."
+    />
+    <meta name="theme-color" content="#0f172a" />
+    <meta name="color-scheme" content="light dark" />
+
+    <!-- Favicons -->
+    <link rel="icon" href="assets/image/favicon.ico" type="image/x-icon" />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/image/favicon-32.png" />
+    <link rel="icon" type="image/png" sizes="192x192" href="assets/image/favicon-192.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/image/favicon-180.png" />
+    <link rel="mask-icon" href="assets/image/logo-symbol.svg" color="#0f172a" />
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+
+    <script type="module" src="assets/js/core.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+        <a class="flex items-center gap-3" href="/">
+          <img src="assets/image/logo.png" class="h-9 w-9 rounded-xl" alt="Логотип GluOne" width="36" height="36" />
+          <span class="font-semibold tracking-tight">GluOne</span>
+        </a>
+        <a href="/auth" class="btn-hero" data-auth-link role="button">Авторизация</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero-bg">
+        <div class="relative max-w-4xl mx-auto px-4 py-12 md:py-16 text-slate-900 dark:text-white">
+          <span
+            class="inline-flex items-center gap-2 rounded-full border border-white/50 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-slate-500 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-400"
+          >
+            <span class="inline-block h-1.5 w-1.5 rounded-full bg-cyan-400 dark:bg-cyan-300" aria-hidden="true"></span>
+            Служба поддержки
+          </span>
+          <h1 class="mt-6 text-3xl font-extrabold leading-tight tracking-tight md:text-4xl">Контакты</h1>
+          <p class="mt-4 text-lg text-slate-700 dark:text-slate-300">GluOne — сервис для управления диабетом.</p>
+          <p class="mt-3 max-w-3xl text-base text-slate-600 dark:text-slate-300">
+            Выберите удобный способ связи — приоритетные каналы вверху.
+          </p>
+        </div>
+      </section>
+
+      <section class="max-w-4xl mx-auto px-4 pb-16 pt-6 text-slate-700 dark:text-slate-300 space-y-12">
+        <div class="space-y-6">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">Как с нами связаться</h2>
+          <div class="grid gap-4 md:grid-cols-2">
+            <div
+              class="rounded-2xl border border-slate-200/80 bg-white/80 p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-700/70 dark:bg-slate-900/60"
+            >
+              <div class="flex items-start gap-4">
+                <span
+                  class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-slate-100 text-2xl dark:bg-slate-800"
+                  aria-hidden="true"
+                >
+                  📧
+                </span>
+                <div>
+                  <p class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    Email поддержки
+                  </p>
+                  <a
+                    class="mt-1 inline-flex items-center gap-2 text-lg font-semibold text-slate-900 underline decoration-from-font decoration-slate-300 transition hover:text-slate-700 hover:decoration-transparent dark:text-white dark:hover:text-slate-100"
+                    href="mailto:notify@gluone.ru"
+                  >
+                    notify@gluone.ru
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path d="M5 4a1 1 0 011-1h9a1 1 0 011 1v9a1 1 0 11-2 0V6.414l-9.293 9.293a1 1 0 01-1.414-1.414L12.586 5H6a1 1 0 01-1-1z" />
+                    </svg>
+                  </a>
+                  <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Письма обрабатываются в порядке очереди.</p>
+                </div>
+              </div>
+            </div>
+
+            <div
+              class="rounded-2xl border border-slate-200/80 bg-white/80 p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-700/70 dark:bg-slate-900/60"
+            >
+              <div class="flex items-start gap-4">
+                <span
+                  class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-slate-100 text-2xl dark:bg-slate-800"
+                  aria-hidden="true"
+                >
+                  💬
+                </span>
+                <div>
+                  <p class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Telegram</p>
+                  <a
+                    class="mt-1 inline-flex items-center gap-2 text-lg font-semibold text-slate-900 underline decoration-from-font decoration-slate-300 transition hover:text-slate-700 hover:decoration-transparent dark:text-white dark:hover:text-slate-100"
+                    href="https://t.me/GluOneNews"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    @GluOneNews
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path d="M3.172 5.172a4 4 0 015.656-5.657l1.586 1.586a1 1 0 001.414 0l1.586-1.586a4 4 0 115.657 5.657l-1.586 1.586a1 1 0 000 1.414l1.586 1.586a4 4 0 11-5.657 5.657l-1.586-1.586a1 1 0 00-1.414 0l-1.586 1.586a4 4 0 11-5.656-5.657l1.586-1.586a1 1 0 000-1.414L3.172 5.172z" />
+                    </svg>
+                  </a>
+                  <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">Новости сервиса и оперативная связь с командой.</p>
+                </div>
+              </div>
+            </div>
+
+            <div
+              class="rounded-2xl border border-slate-200/80 bg-white/80 p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-700/70 dark:bg-slate-900/60 md:col-span-2"
+            >
+              <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div class="flex items-center gap-3">
+                  <span
+                    class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-slate-100 text-2xl dark:bg-slate-800"
+                    aria-hidden="true"
+                  >
+                    🕒
+                  </span>
+                  <div>
+                    <p class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">График</p>
+                    <p class="mt-1 text-lg font-semibold text-slate-900 dark:text-white">Пн–Пт, 10:00–19:00 (Мск)</p>
+                  </div>
+                </div>
+                <dl class="grid gap-2 text-sm text-slate-600 dark:text-slate-400 md:text-right">
+                  <div>
+                    <dt class="font-semibold text-slate-500 dark:text-slate-400">Срок ответа</dt>
+                    <dd>до 1 рабочего дня</dd>
+                  </div>
+                  <div>
+                    <dt class="font-semibold text-slate-500 dark:text-slate-400">Формат поддержки</dt>
+                    <dd>электронная почта и мессенджер</dd>
+                  </div>
+                </dl>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">Реквизиты</h2>
+          <div
+            class="rounded-2xl border border-slate-200/80 bg-white/80 p-6 shadow-sm dark:border-slate-700/70 dark:bg-slate-900/60"
+          >
+            <dl class="grid gap-3 sm:grid-cols-2 sm:gap-x-6">
+              <div>
+                <dt class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">ОГРНИП</dt>
+                <dd class="mt-1 text-base text-slate-900 dark:text-white">324619600076322</dd>
+              </div>
+              <div>
+                <dt class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">ИНН</dt>
+                <dd class="mt-1 text-base text-slate-900 dark:text-white">230110074610</dd>
+              </div>
+              <div class="sm:col-span-2">
+                <dt class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Юридический адрес</dt>
+                <dd class="mt-1 text-base text-slate-900 dark:text-white">
+                  346880, Ростовская обл., г.о. город Батайск, г. Батайск, ул. Северный Массив, д. 15
+                </dd>
+              </div>
+              <div class="sm:col-span-2">
+                <dt class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Почтовый адрес</dt>
+                <dd class="mt-1 text-base text-slate-900 dark:text-white">
+                  совпадает с юридическим (укажите иной, если отличается)
+                </dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+
+        <div class="space-y-4">
+          <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">Для СМИ и партнёров</h2>
+          <div
+            class="rounded-2xl border border-slate-200/80 bg-white/80 p-6 shadow-sm dark:border-slate-700/70 dark:bg-slate-900/60"
+          >
+            <p>
+              По вопросам партнёрств и интервью пишите на
+              <a
+                class="font-semibold text-slate-900 underline decoration-from-font decoration-slate-300 transition hover:text-slate-700 hover:decoration-transparent dark:text-white dark:hover:text-slate-100"
+                href="mailto:notify@gluone.ru"
+              >
+                notify@gluone.ru
+              </a>.
+            </p>
+            <p class="mt-3 text-sm text-slate-600 dark:text-slate-400">
+              В теме письма укажите: «Партнёрство» или «СМИ».
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="border-t border-slate-200 dark:border-slate-700">
+      <div
+        class="max-w-6xl mx-auto flex flex-col gap-4 px-4 py-10 text-sm text-slate-500 dark:text-slate-400 md:flex-row md:items-center md:justify-between"
+      >
+        <p>© <span id="y">2025</span> GluOne</p>
+        <nav class="flex flex-wrap items-center gap-x-5 gap-y-2" aria-label="Нижняя навигация">
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/privacy">Политика конфиденциальности</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/terms.html">Пользовательское соглашение</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/offer">Публичная оферта</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/contacts">Контакты</a>
+        </nav>
+      </div>
+    </footer>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const yearSpan = document.getElementById('y');
+        if (yearSpan) yearSpan.textContent = new Date().getFullYear();
+      });
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -224,8 +224,18 @@
     </section>
 
     <!-- Footer -->
-    <footer class="max-w-6xl mx-auto px-4 py-10 text-sm text-slate-500 dark:text-slate-400 border-t border-slate-200 dark:border-slate-700">
-      © 2025 GluOne · <a href="/privacy" class="underline">Политика конфиденциальности</a> · <a href="/terms.html" class="underline">Пользовательское соглашение</a>
+    <footer class="border-t border-slate-200 dark:border-slate-700">
+      <div
+        class="max-w-6xl mx-auto flex flex-col gap-4 px-4 py-10 text-sm text-slate-500 dark:text-slate-400 md:flex-row md:items-center md:justify-between"
+      >
+        <p>© <span id="y">2025</span> GluOne</p>
+        <nav class="flex flex-wrap items-center gap-x-5 gap-y-2" aria-label="Нижняя навигация">
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/privacy">Политика конфиденциальности</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/terms.html">Пользовательское соглашение</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/offer">Публичная оферта</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/contacts">Контакты</a>
+        </nav>
+      </div>
     </footer>
 
     <!-- Tabs + год -->

--- a/offer.html
+++ b/offer.html
@@ -150,8 +150,18 @@
       </article>
     </main>
 
-    <footer class="max-w-6xl mx-auto px-4 py-10 text-sm text-slate-500 dark:text-slate-400 border-t border-slate-200 dark:border-slate-700">
-      © <span id="y"></span> GluOne · <a href="/privacy" class="underline">Политика конфиденциальности</a>
+    <footer class="border-t border-slate-200 dark:border-slate-700">
+      <div
+        class="max-w-6xl mx-auto flex flex-col gap-4 px-4 py-10 text-sm text-slate-500 dark:text-slate-400 md:flex-row md:items-center md:justify-between"
+      >
+        <p>© <span id="y"></span> GluOne</p>
+        <nav class="flex flex-wrap items-center gap-x-5 gap-y-2" aria-label="Нижняя навигация">
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/privacy">Политика конфиденциальности</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/terms.html">Пользовательское соглашение</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/offer">Публичная оферта</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/contacts">Контакты</a>
+        </nav>
+      </div>
     </footer>
 
     <script>

--- a/privacy.html
+++ b/privacy.html
@@ -305,8 +305,18 @@
       </article>
     </main>
 
-    <footer class="max-w-6xl mx-auto px-4 py-10 text-sm text-slate-500 dark:text-slate-400 border-t border-slate-200 dark:border-slate-700">
-      © <span id="y"></span> GluOne · <a href="/privacy" class="underline">Политика конфиденциальности</a>
+    <footer class="border-t border-slate-200 dark:border-slate-700">
+      <div
+        class="max-w-6xl mx-auto flex flex-col gap-4 px-4 py-10 text-sm text-slate-500 dark:text-slate-400 md:flex-row md:items-center md:justify-between"
+      >
+        <p>© <span id="y"></span> GluOne</p>
+        <nav class="flex flex-wrap items-center gap-x-5 gap-y-2" aria-label="Нижняя навигация">
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/privacy">Политика конфиденциальности</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/terms.html">Пользовательское соглашение</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/offer">Публичная оферта</a>
+          <a class="hover:text-slate-700 dark:hover:text-slate-200" href="/contacts">Контакты</a>
+        </nav>
+      </div>
     </footer>
 
     <script>


### PR DESCRIPTION
## Summary
- add a dedicated contacts page in the legal style with support channels, requisites, and partner guidance
- expand footer navigation across marketing pages and the cabinet to link to contacts alongside existing legal documents
- ensure footer years stay dynamic via shared markup

## Testing
- not run (static HTML)

------
https://chatgpt.com/codex/tasks/task_e_68c9328779fc8327826977b180f32bb4