### PR TITLE
Hide premium indicators for billing-blocked user

### DIFF
--- a/assets/js/cabinet/app.js
+++ b/assets/js/cabinet/app.js
@@ -359,7 +359,7 @@ export default function AccountApp({ bootstrap = {} }) {
           )
         ),
         /* показываем панели по секциям */
-        section === "profile" && React.createElement(ProfilePanel, { profile, hiddenStatus: true }),
+        section === "profile" && React.createElement(ProfilePanel, { profile, hiddenStatus: true, hidePremiumBadge: hideBilling }),
         !hideBilling && section === "subscription" && React.createElement(SubscriptionPanel, {
           onOpenTransfer: () => setTransferContext({ type: 'subscription' }),
           currentDeviceName: currentPremiumDeviceName,
@@ -380,7 +380,7 @@ export default function AccountApp({ bootstrap = {} }) {
           onDeleteAccount: handleDeleteAccount,
           onProfileReload: reloadProfile
         }),
-        section === "devices" && React.createElement(DevicesPanel, { devices, onRevoke: handleRevokeDevice, onDelete: handleDeleteDevice }),
+        section === "devices" && React.createElement(DevicesPanel, { devices, onRevoke: handleRevokeDevice, onDelete: handleDeleteDevice, hidePremiumInfo: hideBilling }),
         !hideBilling && section === "payments" && React.createElement(PaymentsPanel, null),
       )
     ),

--- a/assets/js/cabinet/devices.js
+++ b/assets/js/cabinet/devices.js
@@ -2,7 +2,7 @@
 import { fmtDate, fmtDateTime } from "./helpers.js";
 const { useState, useEffect } = React;
 
-export function DeviceItem({ device, onRevoke, onDelete, disableDelete }) {
+export function DeviceItem({ device, onRevoke, onDelete, disableDelete, hidePremiumInfo = false }) {
   const name = device?.model || "Неизвестное устройство";
   const os = device?.os || "—";
   const build = device?.app_build || "—";
@@ -14,25 +14,57 @@ export function DeviceItem({ device, onRevoke, onDelete, disableDelete }) {
   const revoked = !!device?.revoked;
   const deviceId = device?.device_id;
 
-    return React.createElement(
+  const attributeRows = [
+    React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "OC"),
+    React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, os),
+
+    React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Сборка"),
+    React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, build),
+
+    React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Активность"),
+    React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, active),
+
+    React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Создано"),
+    React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, created),
+
+    React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "IP"),
+    React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, ip),
+  ];
+
+  if (!hidePremiumInfo) {
+    attributeRows.push(
+      React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Премиум"),
+      React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, isPremium ? "Активен" : "Нет"),
+
+      React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Действует до"),
+      React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, isPremium ? premiumUntil : "—"),
+    );
+  }
+
+  attributeRows.push(
+    React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "ID устройства"),
+    React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, deviceId),
+  );
+
+  return React.createElement(
+    "div",
+    { className: "rounded-xl border border-slate-200 p-4 bg-white dark:bg-slate-800 dark:border-slate-700" },
+    React.createElement(
       "div",
-      { className: "rounded-xl border border-slate-200 p-4 bg-white dark:bg-slate-800 dark:border-slate-700" },
+      { className: "flex items-start justify-between" },
+      React.createElement("div", { className: "font-semibold text-slate-800 dark:text-slate-100" }, name),
       React.createElement(
-        "div",
-        { className: "flex items-start justify-between" },
-        React.createElement("div", { className: "font-semibold text-slate-800 dark:text-slate-100" }, name),
-        React.createElement(
-          "span",
-          {
-            className: `text-xs px-2 py-0.5 rounded-full border ${
-              revoked
-                ? "text-slate-600 bg-slate-50 border-slate-200 dark:text-slate-400 dark:bg-slate-700 dark:border-slate-600"
-                : "text-emerald-700 bg-emerald-50 border-emerald-200 dark:text-emerald-200 dark:bg-emerald-900 dark:border-emerald-700"
-            }`,
-          },
-          revoked ? "Отозвано" : "Активно"
-        )
-      ),
+        "span",
+        {
+          className: `text-xs px-2 py-0.5 rounded-full border ${
+            revoked
+              ? "text-slate-600 bg-slate-50 border-slate-200 dark:text-slate-400 dark:bg-slate-700 dark:border-slate-600"
+              : "text-emerald-700 bg-emerald-50 border-emerald-200 dark:text-emerald-200 dark:bg-emerald-900 dark:border-emerald-700"
+          }`,
+        },
+        revoked ? "Отозвано" : "Активно"
+      )
+    ),
 
     // Блок атрибутов: широкая правая колонка
     React.createElement(
@@ -41,58 +73,36 @@ export function DeviceItem({ device, onRevoke, onDelete, disableDelete }) {
         className:
           "mt-3 grid grid-cols-[minmax(140px,220px)_1fr] gap-x-6 gap-y-2 text-sm",
       },
-        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "OC"),
-        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, os),
+      ...attributeRows
+    ),
 
-        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Сборка"),
-        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, build),
-
-        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Активность"),
-        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, active),
-
-        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Создано"),
-        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, created),
-
-        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "IP"),
-        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, ip),
-
-        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Премиум"),
-        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, isPremium ? "Активен" : "Нет"),
-
-        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "Действует до"),
-        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, isPremium ? premiumUntil : "—"),
-
-        React.createElement("div", { className: "text-slate-500 dark:text-slate-400" }, "ID устройства"),
-        React.createElement("div", { className: "text-slate-800 break-words dark:text-slate-100" }, deviceId)
-      ),
-
-      React.createElement(
-        "div",
-        { className: "mt-3 flex justify-end gap-2" },
-        !revoked
-          ? React.createElement(
-              "button",
-              {
-                className:
-                  "rounded-lg bg-slate-900 text-white px-3 py-1.5 text-sm hover:bg-slate-800 dark:bg-slate-700 dark:hover:bg-slate-600",
-                onClick: () => onRevoke(deviceId),
-              },
-              "Выйти с устройства"
-            )
-          : React.createElement(
-              "button",
-              {
-                className: `rounded-lg px-3 py-1.5 text-sm text-white ${
-                  disableDelete
-                    ? "bg-slate-400 cursor-not-allowed dark:bg-slate-600"
-                    : "bg-rose-600 hover:bg-rose-700"
-                }`,
-                disabled: disableDelete,
-                onClick: () => onDelete(deviceId),
-              },
-              "Удалить"
-            )
-      )
+    React.createElement(
+      "div",
+      { className: "mt-3 flex justify-end gap-2" },
+      !revoked
+        ? React.createElement(
+            "button",
+            {
+              className:
+                "rounded-lg bg-slate-900 text-white px-3 py-1.5 text-sm hover:bg-slate-800 dark:bg-slate-700 dark:hover:bg-slate-600",
+              onClick: () => onRevoke(deviceId),
+            },
+            "Выйти с устройства"
+          )
+        : React.createElement(
+            "button",
+            {
+              className: `rounded-lg px-3 py-1.5 text-sm text-white ${
+                disableDelete
+                  ? "bg-slate-400 cursor-not-allowed dark:bg-slate-600"
+                  : "bg-rose-600 hover:bg-rose-700"
+              }`,
+              disabled: disableDelete,
+              onClick: () => onDelete(deviceId),
+            },
+            "Удалить"
+          )
+    )
   );
 }
 

--- a/assets/js/cabinet/panels.js
+++ b/assets/js/cabinet/panels.js
@@ -6,7 +6,7 @@ import { authPaymentsList, authUpdate, authUpdateVerify, authUpdateResend } from
 const { useState, useEffect } = React;
 
 /* ===================== Профиль ===================== */
-export function ProfilePanel({ profile, hiddenStatus = true }) {
+export function ProfilePanel({ profile, hiddenStatus = true, hidePremiumBadge = false }) {
   if (!profile) {
     return React.createElement("div", { className: "space-y-4 w-full" },
       React.createElement(SectionCard, null, React.createElement("div", { className: "text-sm text-slate-600" }, "Загружаем профиль…"))
@@ -21,7 +21,7 @@ export function ProfilePanel({ profile, hiddenStatus = true }) {
           React.createElement("div", { className: "flex-1" },
             React.createElement("div", { className: "flex items-center gap-2 flex-wrap" },
               React.createElement("div", { className: "font-semibold text-slate-900 dark:text-slate-100" }, profile.username || "Без имени"),
-              profile.is_premium && React.createElement(Chip, null, "Premium")
+              profile.is_premium && !hidePremiumBadge && React.createElement(Chip, null, "Premium")
             ),
             React.createElement("div", { className: "text-sm text-slate-500 dark:text-slate-400" }, profile.email ? maskEmail(profile.email) : "—")
           )
@@ -518,13 +518,13 @@ export function SecurityPanel({ profile, onChangePassword, onDeleteAccount, onPr
 }
 
 /* ===================== Устройства ===================== */
-export function DevicesPanel({ devices, onRevoke, onDelete }) {
+export function DevicesPanel({ devices, onRevoke, onDelete, hidePremiumInfo = false }) {
   return React.createElement("div", { className: "space-y-4" },
       React.createElement(SectionCard, { title: "Устройства", footer: React.createElement("div", { className: "text-sm text-slate-500 dark:text-slate-400" }, "Всего устройств: ", devices.length) },
       React.createElement("div", { className: "grid grid-cols-1 md:grid-cols-2 gap-3" },
         devices.map((dev) => {
           const disableDelete = devices.length === 1 && dev.is_premium;
-          return React.createElement(DeviceItem, { key: dev.device_id, device: dev, onRevoke, onDelete, disableDelete });
+          return React.createElement(DeviceItem, { key: dev.device_id, device: dev, onRevoke, onDelete, disableDelete, hidePremiumInfo });
         })
       )
     )


### PR DESCRIPTION
## Summary
- hide the premium badge in the profile panel when billing sections are disabled
- suppress premium status rows in device cards for billing-blocked users

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c99a53c25083279870644431e5a3a8