### PR TITLE
Remove duplicate authorization button from hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,6 @@
               Следить за диабетом стало проще. GluOne объединяет в одном приложении всё, что нужно для контроля здоровья: от уровня сахара и давления до активности и питания.
             </p>
             <div class="mt-7 flex items-center gap-4 flex-wrap">
-              <a href="/auth" class="btn-hero" data-auth-link role="button">Авторизация</a>
               <a
                 href="https://apps.apple.com/app/idXXXXXXXX"
                 target="_blank" rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- remove the authorization button from the hero section so it only appears in the header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca922ac2b88327bd540a1f50f08fe1